### PR TITLE
Prerequisites for supporting in-browser usage

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
                     console: true,
                     module: true,
                     require: true,
-                    process: true
+                    process: true,
+                    setTimeout: true
                 }
             }
         }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,7 +20,18 @@ module.exports = function(grunt) {
                     setTimeout: true
                 }
             }
-        }
+        },
+        browserify: {
+            client: {
+                src: './lib/airtable.js',
+                dest: './airtable.browser.js',
+                options: {
+                    preBundleCB: function(b) {
+                        b.require('./lib/airtable.js', { expose: 'airtable' });
+                    }
+                }
+            }
+        },
     });
 
     // Load the plugin that provides the "uglify" task.
@@ -29,4 +40,5 @@ module.exports = function(grunt) {
     // Default task(s).
     grunt.registerTask('default', ['jshint']);
 
+    grunt.loadNpmTasks('grunt-browserify');
 };

--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -44,7 +44,7 @@ Airtable.configure = function(opts) {
 
 Airtable.base = function(baseId) {
     return new Airtable().base(baseId);
-}
+};
 
 Airtable.Base = Base;
 Airtable.Record = Record;

--- a/lib/base.js
+++ b/lib/base.js
@@ -6,7 +6,7 @@ var Class = require('./class');
 var AirtableError = require('./airtable_error');
 var Table = require('./table');
 
-var jQuery = undefined;
+var jQuery;
 
 var Base = Class.extend({
     init: function(airtable, baseId) {

--- a/lib/base.js
+++ b/lib/base.js
@@ -22,6 +22,7 @@ var Base = Class.extend({
         if (_.isUndefined(jQuery)) {
             this.runActionInNode(method, path, queryParams, bodyData, callback);
         } else {
+            queryParams.forceInsecureCrossDomain = 'ALLOW_ANY_DOMAIN';
             this.runActionWithJQuery(method, path, queryParams, bodyData, callback);
         }
     },

--- a/lib/base.js
+++ b/lib/base.js
@@ -5,6 +5,7 @@ var internalConfig = require('./internal_config');
 var Class = require('./class');
 var AirtableError = require('./airtable_error');
 var Table = require('./table');
+var runAction = require('./run_action');
 
 var Base = Class.extend({
     init: function(airtable, baseId) {
@@ -17,91 +18,9 @@ var Base = Class.extend({
     },
 
     runAction: function(method, path, queryParams, bodyData, callback) {
-        if (_.isUndefined(jQuery)) {
-            this.runActionInNode(method, path, queryParams, bodyData, callback);
-        } else {
-            queryParams.forceInsecureCrossDomain = 'ALLOW_ANY_DOMAIN';
-            this.runActionWithJQuery(method, path, queryParams, bodyData, callback);
-        }
+        runAction(this, method, path, queryParams, bodyData, callback);
     },
-    runActionInNode: function(method, path, queryParams, bodyData, callback) {
-        var that = this;
-        var request = require('request');
-        var url = this._airtable._endpointUrl+'/v' + this._airtable._apiVersionMajor + '/' + this._id + path;
 
-        request[method]({
-            url: url,
-            qs: queryParams,
-            body: bodyData,
-
-            json: true,
-            timeout: internalConfig.REQUEST_TIMEOUT,
-            auth: {
-                bearer: this._airtable._apiKey
-            },
-            agentOptions: {
-                rejectUnauthorized: this._airtable._allowUnauthorizedSsl
-            },
-            headers: {
-                'X-API-VERSION': this._airtable._apiVersion
-            }
-        }, function(error, resp, body) {
-            if (error) {
-                callback(error, resp, body);
-                return;
-            }
-
-            if(resp.statusCode===429 && !that._airtable._noRetryIfRateLimited){
-                setTimeout(function(){
-                    that.runActionInNode(method, path, queryParams, bodyData, callback);
-                }, internalConfig.RETRY_DELAY_IF_RATE_LIMITED);
-                return;
-            }
-
-            error = that._checkStatusForError(resp.statusCode, body);
-
-            if (error) {
-                callback(error, resp, body);
-                return;
-            }
-
-            callback(error, resp, body);
-        });
-    },
-    runActionWithJQuery: function(method, path, queryParams, bodyData, callback) {
-        var that = this;
-
-        var url = this._airtable._endpointUrl+'/v' + this._airtable._apiVersionMajor + '/' + this._id + path + '?' + jQuery.param(queryParams);
-
-        jQuery.ajax(url, {
-            contentType: 'application/json',
-            type: method,
-
-            data: JSON.stringify(bodyData),
-            processData: false,
-            dataType: 'json',
-            timeout: internalConfig.REQUEST_TIMEOUT,
-
-            headers: {
-                'Authorization': 'Bearer ' + this._airtable._apiKey,
-                'X-API-VERSION': this._airtable._apiVersion
-            },
-            success: function(data, textStatus, jqXHR) {
-                callback(null, null, data);
-            },
-            error: function(jqXHR, textStatus) {
-                var error;
-                if(jqXHR.statusCode()===429 && !that._airtable._noRetryIfRateLimited){
-                    setTimeout(function(){
-                        that.runActionWithJQuery(method, path, queryParams, bodyData, callback);
-                    }, internalConfig.RETRY_DELAY_IF_RATE_LIMITED);
-                    return;
-                }
-                error = that._checkStatusForError(jqXHR.statusCode(), jqXHR.respnoseText);
-                callback(error);
-            }
-        });
-    },
     _checkStatusForError: function(statusCode, body) {
         if (statusCode === 401) {
             return new AirtableError('AUTHENTICATION_REQUIRED', 'You should provide valid api key to perform this operation', statusCode);

--- a/lib/base.js
+++ b/lib/base.js
@@ -79,7 +79,8 @@ var Base = Class.extend({
             contentType: 'application/json',
             type: method,
 
-            data: bodyData,
+            data: JSON.stringify(bodyData),
+            processData: false,
             dataType: 'json',
             timeout: internalConfig.REQUEST_TIMEOUT,
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -6,8 +6,6 @@ var Class = require('./class');
 var AirtableError = require('./airtable_error');
 var Table = require('./table');
 
-var jQuery;
-
 var Base = Class.extend({
     init: function(airtable, baseId) {
         this._airtable = airtable;

--- a/lib/record.js
+++ b/lib/record.js
@@ -28,7 +28,7 @@ var Record = Class.extend({
         var that = this;
         if (!done) {
             done = opts;
-            opts = {}
+            opts = {};
         }
         var updateBody = _.extend({
             fields: cellValuesByName
@@ -45,7 +45,7 @@ var Record = Class.extend({
         var that = this;
         if (!done) {
             done = opts;
-            opts = {}
+            opts = {};
         }
         var updateBody = _.extend({
             fields: cellValuesByName

--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var internalConfig = require('./internal_config');
+var request = require('request');
+
+function runAction(base, method, path, queryParams, bodyData, callback) {
+    var url = base._airtable._endpointUrl+'/v' + base._airtable._apiVersionMajor + '/' + base._id + path;
+
+    request[method]({
+        url: url,
+        qs: queryParams,
+        body: bodyData,
+
+        json: true,
+        timeout: internalConfig.REQUEST_TIMEOUT,
+        auth: {
+            bearer: base._airtable._apiKey
+        },
+        agentOptions: {
+            rejectUnauthorized: base._airtable._allowUnauthorizedSsl
+        },
+        headers: {
+            'X-API-VERSION': base._airtable._apiVersion
+        }
+    }, function(error, resp, body) {
+        if (error) {
+            callback(error, resp, body);
+            return;
+        }
+
+        if(resp.statusCode===429 && !base._airtable._noRetryIfRateLimited){
+            setTimeout(function(){
+                runAction(base, method, path, queryParams, bodyData, callback);
+            }, internalConfig.RETRY_DELAY_IF_RATE_LIMITED);
+            return;
+        }
+
+        error = base._checkStatusForError(resp.statusCode, body);
+
+        if (error) {
+            callback(error, resp, body);
+            return;
+        }
+
+        callback(error, resp, body);
+    });
+}
+
+module.exports = runAction;

--- a/lib/run_action_with_jquery.js
+++ b/lib/run_action_with_jquery.js
@@ -1,0 +1,42 @@
+/*globals jQuery */
+'use strict';
+
+var internalConfig = require('./internal_config');
+
+function runActionWithJQuery(base, method, path, queryParams, bodyData, callback) {
+    queryParams.forceInsecureCrossDomain = 'ALLOW_ANY_DOMAIN';
+
+    var url = base._airtable._endpointUrl+'/v' + base._airtable._apiVersionMajor + '/' + base._id + path + '?' + jQuery.param(queryParams);
+
+    jQuery.ajax(url, {
+        contentType: 'application/json',
+        type: method,
+
+        data: JSON.stringify(bodyData),
+        processData: false,
+        dataType: 'json',
+        timeout: internalConfig.REQUEST_TIMEOUT,
+
+        headers: {
+            'Authorization': 'Bearer ' + base._airtable._apiKey,
+            // TODO: uncomment when the server is fixed to allow this header:
+            //'X-API-VERSION': base._airtable._apiVersion
+        },
+        success: function(data, textStatus, jqXHR) {
+            callback(null, null, data);
+        },
+        error: function(jqXHR, textStatus) {
+            var error;
+            if(jqXHR.statusCode()===429 && !base._airtable._noRetryIfRateLimited){
+                setTimeout(function(){
+                    runActionWithJQuery(base, method, path, queryParams, bodyData, callback);
+                }, internalConfig.RETRY_DELAY_IF_RATE_LIMITED);
+                return;
+            }
+            error = base._checkStatusForError(jqXHR.statusCode(), jqXHR.respnoseText);
+            callback(error);
+        }
+    });
+}
+
+module.exports = runActionWithJQuery;

--- a/package.json
+++ b/package.json
@@ -1,27 +1,30 @@
 {
-    "name": "airtable",
-    "version": "0.2.0",
-    "homepage": "https://github.com/airtable/airtable.js",
-    "repository": "git://github.com/airtable/airtable.js.git",
-
-    "private": false,
-    "dependencies": {
-        "async": "0.9.0",
-        "request": "2.42.0",
-        "lodash": "2.4.1"
-    },
-    "main" : "./lib/airtable.js",
-    "devDependencies": {
-        "grunt": "~0.4.5",
-        "grunt-contrib-jshint": "~0.10.0"
-    },
-    "keywords": [
-        "airtable",
-        "productivity",
-        "database",
-        "spreadsheet"
-    ],
-    "engines": {
-        "node": ">= 0.10.0"
-    }
+  "name": "airtable",
+  "version": "0.2.0",
+  "homepage": "https://github.com/airtable/airtable.js",
+  "repository": "git://github.com/airtable/airtable.js.git",
+  "private": false,
+  "dependencies": {
+    "async": "0.9.0",
+    "request": "2.42.0",
+    "lodash": "2.4.1"
+  },
+  "main": "./lib/airtable.js",
+  "browser": {
+    "./lib/run_action.js": "./lib/run_action_with_jquery.js"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-browserify": "^3.8.0",
+    "grunt-contrib-jshint": "~0.10.0"
+  },
+  "keywords": [
+    "airtable",
+    "productivity",
+    "database",
+    "spreadsheet"
+  ],
+  "engines": {
+    "node": ">= 0.10.0"
+  }
 }


### PR DESCRIPTION
Changes:
- Fix JSHint warnings
- Allow cross-domain requests when using jQuery
- Send request body as JSON instead of query-string
- Remove jQuery declaration to avoid shadowing real jQuery if it's included on the page