### PR TITLE
Fix deprecated use of arguments.callee

### DIFF
--- a/lib/class.js
+++ b/lib/class.js
@@ -13,7 +13,7 @@
     var Class = function(){};
 
     // Create a new Class that inherits from this class
-    Class.extend = function(prop) {
+    Class.extend = function extender(prop) {
         var _super = this.prototype;
 
         // Instantiate a base class (but only create the instance,
@@ -60,7 +60,7 @@
         Class.prototype.constructor = Class;
 
         // And make this class extendable
-        Class.extend = arguments.callee;
+        Class.extend = extender;
 
         return Class;
     };


### PR DESCRIPTION
Without this, a TypeError is thrown in ES5 strict mode.