### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -14,7 +14,7 @@ var Record = require('./record');
 var Table = Class.extend({
     init: function(base, tableId, tableName) {
         this._base = base;
-        assert(tableId || tableName, 'Table name or table ID is require');
+        assert(tableId || tableName, 'Table name or table ID is required');
         this.id = tableId;
         this.name = tableName;
 


### PR DESCRIPTION
This fixes a typo in the error message when trying to access a table without a table id or table name.