### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "repository": "git://github.com/airtable/airtable.js.git",
   "private": false,
   "dependencies": {
-    "async": "0.9.0",
-    "request": "2.42.0",
-    "lodash": "2.4.1"
+    "async": "^1.5.2",
+    "lodash": "^4.13.1",
+    "request": "^2.73.0"
   },
   "main": "./lib/airtable.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "repository": "git://github.com/airtable/airtable.js.git",
   "private": false,
   "dependencies": {
-    "async": "^1.5.2",
-    "lodash": "^4.13.1",
-    "request": "^2.73.0"
+    "async": "1.5.2",
+    "lodash": "2.4.1",
+    "request": "2.73.0"
   },
   "main": "./lib/airtable.js",
   "browser": {


### PR DESCRIPTION
Main reason for doing it is because `request@2.42` depends on `hawk@1.1.1` which has vulnerability (Regular Expression Denial of Service)