### PR TITLE
bump the request module to remove tough-cookie vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "async": "1.5.2",
     "lodash": "2.4.1",
-    "request": "2.73.0"
+    "request": "2.79.0"
   },
   "main": "./lib/airtable.js",
   "browser": {


### PR DESCRIPTION
The older version of request uses a vulnerable version of tough-cookie.  Just a bump in version number.  I would re-run tests, but I don't know how from these docs.