### PR TITLE
Only send the request body if there's data to send

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -60,7 +60,7 @@ var Query = Class.extend({
         var params = _.clone(this._params);
 
         var inner = function() {
-            that._table._base.runAction('get', path, params, {}, function(err, response, result) {
+            that._table._base.runAction('get', path, params, null, function(err, response, result) {
                 if (err) {
                     done(err, null);
                 } else {

--- a/lib/record.js
+++ b/lib/record.js
@@ -59,7 +59,7 @@ var Record = Class.extend({
     },
     destroy: function(done) {
         var that = this;
-        this._table._base.runAction('delete', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, {}, function(err, response, results) {
+        this._table._base.runAction('delete', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, null, function(err, response, results) {
             if (err) { done(err); return; }
 
             done(null, that);
@@ -68,7 +68,7 @@ var Record = Class.extend({
 
     fetch: function(done) {
         var that = this;
-        this._table._base.runAction('get', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, {}, function(err, response, results) {
+        this._table._base.runAction('get', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, null, function(err, response, results) {
             if (err) { done(err); return; }
 
             that.setRawJson(results);

--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -9,10 +9,9 @@ var request = require('request');
 function runAction(base, method, path, queryParams, bodyData, callback) {
     var url = base._airtable._endpointUrl + '/v' + base._airtable._apiVersionMajor + '/' + base._id + path + '?' + objectToQueryParamString(queryParams);
 
-    request({
+    var options = {
         method: method.toUpperCase(),
         url: url,
-        body: bodyData,
         json: true,
         timeout: base._airtable.requestTimeout,
         headers: {
@@ -24,7 +23,13 @@ function runAction(base, method, path, queryParams, bodyData, callback) {
         agentOptions: {
             rejectUnauthorized: base._airtable._allowUnauthorizedSsl
         },
-    }, function(error, resp, body) {
+    };
+
+    if (bodyData !== null) {
+        options['body'] = bodyData
+    }
+
+    request(options, function(error, resp, body) {
         if (error) {
             callback(error, resp, body);
             return;

--- a/lib/table.js
+++ b/lib/table.js
@@ -113,7 +113,7 @@ var Table = Class.extend({
 
         async.waterfall([
             function(next) {
-                that._base.runAction('get', '/' + that._urlEncodedNameOrId() + '/', listRecordsParameters, {}, next);
+                that._base.runAction('get', '/' + that._urlEncodedNameOrId() + '/', listRecordsParameters, null, next);
             },
             function(response, results, next) {
                 var records = _.map(results.records, function(recordJson) {


### PR DESCRIPTION
Previously body data was being sent with all requests, this change only sends body data when it's present.

We're using AWS Cloudfront to cache Airtable requests but Cloudfront rejects any GET requests with body data (turns out there is no current need in Airtable for GET requests to contain a body)
[Cloudfront docs](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustom-get-body)

Fix for: #23 