### PR TITLE
Add optional promise-based API

### DIFF
--- a/lib/callback_to_promise.js
+++ b/lib/callback_to_promise.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Given a function fn that takes a callback as its last argument, returns
+ * a new version of the function that takes the callback optionally. If
+ * the function is not called with a callback for the last argument, the
+ * function will return a promise instead.
+ */
+function callbackToPromise(fn, context) {
+    return function() {
+        var lastArg = arguments.length > 0 ? arguments[arguments.length - 1] : null;
+        if (typeof lastArg === 'function') {
+            fn.apply(context, arguments);
+        } else {
+            var args = [];
+            for (var i = 0; i < arguments.length; i++) {
+                args.push(arguments[i]);
+            }
+            return new Promise(function(resolve, reject) {
+                args.push(function(err, result) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(result);
+                    }
+                });
+                fn.apply(context, args);
+            });
+        }
+    };
+}
+
+module.exports = callbackToPromise;

--- a/lib/callback_to_promise.js
+++ b/lib/callback_to_promise.js
@@ -6,10 +6,14 @@
  * the function is not called with a callback for the last argument, the
  * function will return a promise instead.
  */
-function callbackToPromise(fn, context) {
+function callbackToPromise(fn, context, callbackArgIndex) {
     return function() {
-        var lastArg = arguments.length > 0 ? arguments[arguments.length - 1] : null;
-        if (typeof lastArg === 'function') {
+        // If callbackArgIndex isn't provided, use the last argument.
+        if (callbackArgIndex === undefined) {
+            callbackArgIndex = arguments.length > 0 ? arguments.length - 1 : 0;
+        }
+        var callbackArg = arguments[callbackArgIndex];
+        if (typeof callbackArg === 'function') {
             fn.apply(context, arguments);
         } else {
             var args = [];

--- a/lib/query.js
+++ b/lib/query.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
 var check = require('./typecheck');
 var Class = require('./class');
 var Record = require('./record');
+var callbackToPromise = require('./callback_to_promise');
 
 var Query = Class.extend({
     /**
@@ -21,6 +22,10 @@ var Query = Class.extend({
 
         this._table = table;
         this._params = params;
+
+        this.firstPage = callbackToPromise(this.firstPage, this);
+        this.eachPage = callbackToPromise(this.eachPage, this, 1);
+        this.all = callbackToPromise(this.all, this);
     },
 
     /**
@@ -87,6 +92,25 @@ var Query = Class.extend({
 
         inner();
     },
+    /**
+     * Fetches all pages of results asynchronously. May take a long time.
+     */
+    all: function(done) {
+        assert(_.isFunction(done),
+            'The first parameter to `all` must be a function');
+
+        var allRecords = [];
+        this.eachPage(function(pageRecords, fetchNextPage) {
+            allRecords.push.apply(allRecords, pageRecords);
+            fetchNextPage();
+        }, function(err) {
+            if (err) {
+                done(err, null);
+            } else {
+                done(null, allRecords);
+            }
+        });
+    }
 });
 
 Query.paramValidators = {

--- a/lib/record.js
+++ b/lib/record.js
@@ -3,12 +3,20 @@
 var _ = require('lodash');
 
 var Class = require('./class');
+var callbackToPromise = require('./callback_to_promise');
 
 var Record = Class.extend({
     init: function(table, recordId, recordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
         this.setRawJson(recordJson);
+
+        this.save = callbackToPromise(this.save, this);
+        this.patchUpdate = callbackToPromise(this.patchUpdate, this);
+        this.putUpdate = callbackToPromise(this.putUpdate, this);
+        this.destroy = callbackToPromise(this.destroy, this);
+        this.fetch = callbackToPromise(this.fetch, this);
+
         this.updateFields = this.patchUpdate;
         this.replaceFields = this.putUpdate;
     },

--- a/lib/table.js
+++ b/lib/table.js
@@ -10,6 +10,7 @@ var Class = require('./class');
 var deprecate = require('./deprecate');
 var Query = require('./query');
 var Record = require('./record');
+var callbackToPromise = require('./callback_to_promise');
 
 var Table = Class.extend({
     init: function(base, tableId, tableName) {
@@ -19,12 +20,12 @@ var Table = Class.extend({
         this.name = tableName;
 
         // Public API
-        this.find = this._findRecordById.bind(this);
+        this.find = callbackToPromise(this._findRecordById, this);
         this.select = this._selectRecords.bind(this);
-        this.create = this._createRecord.bind(this);
-        this.update = this._updateRecord.bind(this);
-        this.destroy = this._destroyRecord.bind(this);
-        this.replace = this._replaceRecord.bind(this);
+        this.create = callbackToPromise(this._createRecord, this);
+        this.update = callbackToPromise(this._updateRecord, this);
+        this.destroy = callbackToPromise(this._destroyRecord, this);
+        this.replace = callbackToPromise(this._replaceRecord, this);
 
         // Deprecated API
         this.list = deprecate(this._listRecords.bind(this),


### PR DESCRIPTION
The following methods now return a Promise if a callback isn't specified:

```
Query
  firstPage
  eachPage
  all (added in this change)
Record
  save
  patchUpdate
  putUpdate
  destroy
  fetch
Table
  find
  create
  update
  destroy
  replace
```