### PR TITLE
Fix small error where Webpack fail compilation - run_action.js

### DIFF
--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var internalConfig = require('./internal_config');
+var internalConfig = require('./internal_config.json');
 var objectToQueryParamString = require('./object_to_query_param_string');
 
 // This will become require('xhr') in the browser.


### PR DESCRIPTION
By importing file without .json extension Webpack fail to compile my application, that's why i have added this small typo