### PR TITLE
Support dotenv by loading process.env later

### DIFF
--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -12,13 +12,15 @@ var Airtable = Class.extend({
     init: function(opts) {
         opts = opts || {};
 
-        this._apiKey = opts.apiKey || Airtable.apiKey || Airtable.default_config.apiKey;
-        this._endpointUrl = opts.endpointUrl || Airtable.endpointUrl || Airtable.default_config.endpointUrl;
-        this._apiVersion = opts.apiVersion || Airtable.apiVersion || Airtable.default_config.apiVersion;
+        const default_config = Airtable.default_config();
+
+        this._apiKey = opts.apiKey || Airtable.apiKey || default_config.apiKey;
+        this._endpointUrl = opts.endpointUrl || Airtable.endpointUrl || default_config.endpointUrl;
+        this._apiVersion = opts.apiVersion || Airtable.apiVersion || default_config.apiVersion;
         this._apiVersionMajor = this._apiVersion.split('.')[0];
-        this._allowUnauthorizedSsl = opts.allowUnauthorizedSsl || Airtable.allowUnauthorizedSsl || Airtable.default_config.allowUnauthorizedSsl;
-        this._noRetryIfRateLimited = opts.noRetryIfRateLimited || Airtable.noRetryIfRateLimited || Airtable.default_config.noRetryIfRateLimited;
-        this.requestTimeout = opts.requestTimeout || Airtable.default_config.requestTimeout;
+        this._allowUnauthorizedSsl = opts.allowUnauthorizedSsl || Airtable.allowUnauthorizedSsl || default_config.allowUnauthorizedSsl;
+        this._noRetryIfRateLimited = opts.noRetryIfRateLimited || Airtable.noRetryIfRateLimited || default_config.noRetryIfRateLimited;
+        this.requestTimeout = opts.requestTimeout || default_config.requestTimeout;
 
         assert(this._apiKey, 'API key is required to connect to Airtable');
     },
@@ -28,14 +30,14 @@ var Airtable = Class.extend({
     }
 });
 
-Airtable.default_config = {
+Airtable.default_config = () => ({
     endpointUrl: process.env.AIRTABLE_ENDPOINT_URL || 'https://api.airtable.com',
     apiVersion: '0.1.0',
     apiKey: process.env.AIRTABLE_API_KEY,
     allowUnauthorizedSsl: false,
     noRetryIfRateLimited: false,
     requestTimeout: 300 * 1000, // 5 minutes
-};
+});
 
 Airtable.configure = function(opts) {
     Airtable.apiKey = opts.apiKey;


### PR DESCRIPTION
[dotenv](https://github.com/motdotla/dotenv) is a popular library for loading runtime config from a .env file. It's useful for lightweight development. The way it works is a little dirty because it modifies process.env. It's a tricky to use with Airtable, which grabs its config at module load time.

If loading the environment is deferred until Airtable is used, it works like a charm.