### PR TITLE
Fix JSHint and linting errors

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,6 +1,6 @@
-module.exports = function(grunt) {
-    'use strict';
+'use strict';
 
+module.exports = function(grunt) {
     var pkg = grunt.file.readJSON('package.json');
 
     // Project configuration.
@@ -23,7 +23,9 @@ module.exports = function(grunt) {
                     jest: true,
                     describe: true,
                     it: true,
-                    expect: true
+                    expect: true,
+                    Promise: true,
+                    __dirname: true
                 }
             }
         },

--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -12,7 +12,7 @@ var Airtable = Class.extend({
     init: function(opts) {
         opts = opts || {};
 
-        const default_config = Airtable.default_config();
+        var default_config = Airtable.default_config();
 
         this._apiKey = opts.apiKey || Airtable.apiKey || default_config.apiKey;
         this._endpointUrl = opts.endpointUrl || Airtable.endpointUrl || default_config.endpointUrl;
@@ -30,14 +30,16 @@ var Airtable = Class.extend({
     }
 });
 
-Airtable.default_config = () => ({
-    endpointUrl: process.env.AIRTABLE_ENDPOINT_URL || 'https://api.airtable.com',
-    apiVersion: '0.1.0',
-    apiKey: process.env.AIRTABLE_API_KEY,
-    allowUnauthorizedSsl: false,
-    noRetryIfRateLimited: false,
-    requestTimeout: 300 * 1000, // 5 minutes
-});
+Airtable.default_config = function () {
+    return {
+        endpointUrl: process.env.AIRTABLE_ENDPOINT_URL || 'https://api.airtable.com',
+        apiVersion: '0.1.0',
+        apiKey: process.env.AIRTABLE_API_KEY,
+        allowUnauthorizedSsl: false,
+        noRetryIfRateLimited: false,
+        requestTimeout: 300 * 1000, // 5 minutes
+    };
+};
 
 Airtable.configure = function(opts) {
     Airtable.apiKey = opts.apiKey;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,33 +1172,36 @@
       }
     },
     "cli": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
-      "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "3.2.11"
+        "glob": "7.1.2"
       },
       "dependencies": {
         "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
             "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -3081,13 +3084,50 @@
       }
     },
     "grunt-contrib-jshint": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
-      "integrity": "sha1-V+vMyofo8yevZkXYo8WG1IReTYE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
+      "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
       "dev": true,
       "requires": {
+        "chalk": "1.1.3",
         "hooker": "0.2.3",
-        "jshint": "2.5.11"
+        "jshint": "2.9.5"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "grunt-legacy-log": {
@@ -5639,36 +5679,35 @@
       "dev": true
     },
     "jshint": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
-      "integrity": "sha1-4tlYWLuxqngwAQii6BCZ+wlWIuA=",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "0.6.6",
+        "cli": "1.0.1",
         "console-browserify": "1.1.0",
         "exit": "0.1.2",
         "htmlparser2": "3.8.3",
-        "minimatch": "1.0.0",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
         "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4",
-        "underscore": "1.6.0"
+        "strip-json-comments": "1.0.4"
       },
       "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        },
         "minimatch": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "brace-expansion": "1.1.11"
           }
-        },
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "repository": "git://github.com/airtable/airtable.js.git",
   "private": false,
   "scripts": {
+    "pretest": "npm run lint",
+    "lint": "grunt jshint",
     "test": "jest --env node"
   },
   "dependencies": {
@@ -21,7 +23,7 @@
     "envify": "^4.1.0",
     "grunt": "~0.4.5",
     "grunt-browserify": "^5.3.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "^1.1.0",
     "jest": "^23.2.0"
   },
   "keywords": [

--- a/test/browser_build.test.js
+++ b/test/browser_build.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 
@@ -11,12 +13,12 @@ describe('browser build', function () {
         return;
       }
 
-      const exceptions = [
+      var exceptions = [
         /process\.env\.NODE_DEBUG/,
         /process\.env = {}/
-      ]
+      ];
 
-      const builtWithoutExceptions = exceptions.reduce(function (result, exception) {
+      var builtWithoutExceptions = exceptions.reduce(function (result, exception) {
         return result.replace(exception, '');
       }, builtJs);
 


### PR DESCRIPTION
This PR:

- fixes JSHint (`grunt jshint` now works)
- fixes several linting errors we weren't catching before (including usage of some ES6 features)
- makes `npm run lint` run JSHint
- makes `npm test` run JSHint before running tests

Didn't run a build here.