### PR TITLE
Properly report error if select() is called without any args

### DIFF
--- a/lib/callback_to_promise.js
+++ b/lib/callback_to_promise.js
@@ -17,7 +17,11 @@ function callbackToPromise(fn, context, callbackArgIndex) {
             fn.apply(context, arguments);
         } else {
             var args = [];
-            for (var i = 0; i < arguments.length; i++) {
+            // If an explicit callbackArgIndex is set, but the function is called
+            // with too few arguments, we want to push undefined onto args so that
+            // our constructed callback ends up at the right index.
+            var argLen = Math.max(arguments.length, callbackArgIndex);
+            for (var i = 0; i < argLen; i++) {
                 args.push(arguments[i]);
             }
             return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Fixes the issue reported in this comment: https://github.com/Airtable/airtable.js/issues/69#issuecomment-418604012

Previously, the promise callback would get set as the first arg if select() was called without arguments, which led to confusing behavior, since the promise would reject with the first page of records. Now, it'll throw an error, since select() must be called with at least 1 callback.