### PR TITLE
v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.8
+ * Remove `async` dependency (#76)
+ * Shrink size of browser build by about half (#76)
+
 # v0.5.7
  * Support dotenv for loading config (#59)
  * Improve error message is select() is called without args (#70)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "homepage": "https://github.com/airtable/airtable.js",
   "repository": "git://github.com/airtable/airtable.js.git",
   "private": false,


### PR DESCRIPTION
`grunt browserify` had already been run which is why it doesn't show up in this diff.