### PR TITLE
Update Lodash to 4.17.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4378,9 +4378,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest --env node"
   },
   "dependencies": {
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "request": "2.88.0",
     "xhr": "2.3.3"
   },


### PR DESCRIPTION
Lodash <4.17.11 has a minor prototype pollution bug. It doesn't affect any part of Lodash we use, but npm will give you a warning when an old version of Lodash is installed.

This fixes that so people stop getting the warning when installing Airtable.js.

See #79 for the original report.