### PR TITLE
Add "license" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "airtable",
   "version": "0.5.10",
+  "license": "MIT",
   "homepage": "https://github.com/airtable/airtable.js",
   "repository": "git://github.com/airtable/airtable.js.git",
   "private": false,


### PR DESCRIPTION
This adds a ["license" field to `package.json`][1], which will help users when trying to scan their dependencies' licenses. (It also silences an npm warning that it's missing when developing.)

[1]: https://docs.npmjs.com/files/package.json#license