### PR TITLE
Add support for batch record updates

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -26,9 +26,9 @@ var Table = Class.extend({
         this.find = callbackToPromise(this._findRecordById, this);
         this.select = this._selectRecords.bind(this);
         this.create = callbackToPromise(this._createRecords, this);
-        this.update = callbackToPromise(this._updateRecord, this);
+        this.update = callbackToPromise(this._updateRecords.bind(this, false), this);
+        this.replace = callbackToPromise(this._updateRecords.bind(this, true), this);
         this.destroy = callbackToPromise(this._destroyRecord, this);
-        this.replace = callbackToPromise(this._replaceRecord, this);
 
         // Deprecated API
         this.list = deprecate(this._listRecords.bind(this),
@@ -111,22 +111,37 @@ var Table = Class.extend({
             done(null, result);
         });
     },
-    _updateRecord: function(recordId, recordData, opts, done) {
-        var record = new Record(this, recordId);
-        if (!done) {
-            done = opts;
-            record.patchUpdate(recordData, done);
+    _updateRecords: function(isDestructiveUpdate, recordsDataOrRecordId, recordDataOrOptsOrDone, optsOrDone, done) {
+        var opts;
+
+        if (isArray(recordsDataOrRecordId)) {
+            var that = this;
+            var recordsData = recordsDataOrRecordId;
+            opts = isPlainObject(recordDataOrOptsOrDone) ? recordDataOrOptsOrDone : {};
+            done = optsOrDone || recordDataOrOptsOrDone;
+
+            var method = isDestructiveUpdate ? 'put' : 'patch';
+            var requestData = assign({records: recordsData}, opts);
+            this._base.runAction(method, '/' + this._urlEncodedNameOrId() + '/', {}, requestData, function(err, resp, body) {
+                if (err) { done(err); return; }
+
+                var result = body.records.map(function (record) {
+                    return new Record(that, record.id, record);
+                });
+                done(null, result);
+            });
         } else {
-            record.patchUpdate(recordData, opts, done);
-        }
-    },
-    _replaceRecord: function(recordId, recordData, opts, done) {
-        var record = new Record(this, recordId);
-        if (!done) {
-            done = opts;
-            record.putUpdate(recordData, done);
-        } else {
-            record.putUpdate(recordData, opts, done);
+            var recordId = recordsDataOrRecordId;
+            var recordData = recordDataOrOptsOrDone;
+            opts = isPlainObject(optsOrDone) ? optsOrDone : {};
+            done = done || optsOrDone;
+
+            var record = new Record(this, recordId);
+            if (isDestructiveUpdate) {
+                record.putUpdate(recordData, opts, done);
+            } else {
+                record.patchUpdate(recordData, opts, done);
+            }
         }
     },
     _destroyRecord: function(recordIdsOrId, done) {

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -30,6 +30,40 @@ function getMockEnvironmentAsync() {
     res.json(responseBody);
   });
 
+  const singleRecordUpdate = [
+    _checkParamsMiddleware,
+    function(req, res, next) {
+      var fields = req.body.typecast ? {typecasted: true} : req.body.fields;
+
+      res.json({
+        id: req.params.recordId,
+        createdTime: FAKE_CREATED_TIME,
+        fields: fields,
+      });
+    },
+  ];
+  const batchRecordUpdate = [
+    _checkParamsMiddleware,
+    function(req, res, next) {
+      res.json({
+        records: req.body.records.map(function (record) {
+          var fields = req.body.typecast ? {typecasted: true} : record.fields;
+          return {
+            id: record.id,
+            createdTime: FAKE_CREATED_TIME,
+            fields: fields
+          };
+        }),
+      });
+    },
+  ];
+
+  app.patch('/v0/:baseId/:tableIdOrName/:recordId', singleRecordUpdate);
+  app.put('/v0/:baseId/:tableIdOrName/:recordId', singleRecordUpdate);
+
+  app.patch('/v0/:baseId/:tableIdOrName', batchRecordUpdate);
+  app.put('/v0/:baseId/:tableIdOrName', batchRecordUpdate);
+
   app.delete('/v0/:baseId/:tableIdOrName/:recordId', _checkParamsMiddleware, function (req, res, next) {
     res.json({
       id: req.params.recordId,

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+var testHelpers = require('./test_helpers');
+
+describe('record updates', function () {
+  var airtable;
+  var teardownAsync;
+
+  beforeAll(function () {
+    return testHelpers.getMockEnvironmentAsync().then(function (env) {
+      airtable = env.airtable;
+      teardownAsync = env.teardownAsync;
+    });
+  });
+
+  afterAll(function () {
+    return teardownAsync();
+  });
+
+  describe('non-destructive updates', function () {
+    it('can update one record', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .update('rec123', {
+          foo: 'boo',
+          bar: 'yar',
+        })
+        .then(function (updatedRecord) {
+          expect(updatedRecord.id).toBe('rec123');
+          expect(updatedRecord.get('foo')).toBe('boo');
+          expect(updatedRecord.get('bar')).toBe('yar');
+        });
+    });
+
+    it('can update one record and call a callback', function (done) {
+      airtable
+        .base('app123')
+        .table('Table')
+        .update('rec123', {
+          foo: 'boo',
+          bar: 'yar',
+        }, function (err, updatedRecord) {
+          expect(err).toBeNull();
+          expect(updatedRecord.id).toBe('rec123');
+          expect(updatedRecord.get('foo')).toBe('boo');
+          expect(updatedRecord.get('bar')).toBe('yar');
+          done();
+        });
+    });
+
+    it('can add the "typecast" parameter when updating one record', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .update('rec123', {
+          foo: 'boo',
+          bar: 'yar',
+        }, {typecast: true})
+        .then(function (updatedRecord) {
+          expect(updatedRecord.id).toBe('rec123');
+          expect(updatedRecord.get('typecasted')).toBe(true);
+        });
+    });
+
+    it('can update one record with an array', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .update([{
+          id: 'rec123',
+          fields: {foo: 'boo'},
+        }])
+        .then(function (updatedRecords) {
+          expect(updatedRecords).toHaveLength(1);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('foo')).toBe('boo');
+        });
+    });
+
+    it('can update two records', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .update([
+          {
+            id: 'rec123',
+            fields: {foo: 'boo'},
+          },
+          {
+            id: 'rec456',
+            fields: {bar: 'yar'},
+          },
+        ])
+        .then(function (updatedRecords) {
+          expect(updatedRecords).toHaveLength(2);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('foo')).toBe('boo');
+          expect(updatedRecords[1].id).toBe('rec456');
+          expect(updatedRecords[1].get('bar')).toBe('yar');
+        });
+    });
+
+    it('can update two records and call a callback', function (done) {
+      airtable
+        .base('app123')
+        .table('Table')
+        .update([
+          {
+            id: 'rec123',
+            fields: {foo: 'boo'},
+          },
+          {
+            id: 'rec456',
+            fields: {bar: 'yar'},
+          },
+        ], function (err, updatedRecords) {
+          expect(err).toBeNull();
+          expect(updatedRecords).toHaveLength(2);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('foo')).toBe('boo');
+          expect(updatedRecords[1].id).toBe('rec456');
+          expect(updatedRecords[1].get('bar')).toBe('yar');
+          done();
+        });
+    });
+
+    it('can update two records with the "typecast" parameter', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .update([
+          {
+            id: 'rec123',
+            fields: {foo: 'boo'},
+          },
+          {
+            id: 'rec456',
+            fields: {bar: 'yar'},
+          },
+        ], {typecast: true})
+        .then(function (updatedRecords) {
+          expect(updatedRecords).toHaveLength(2);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('typecasted')).toBe(true);
+          expect(updatedRecords[1].id).toBe('rec456');
+          expect(updatedRecords[1].get('typecasted')).toBe(true);
+        });
+    });
+  });
+
+  describe('destructive updates', function () {
+    it('can update one record', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .replace('rec123', {
+          foo: 'boo',
+          bar: 'yar',
+        })
+        .then(function (updatedRecord) {
+          expect(updatedRecord.id).toBe('rec123');
+          expect(updatedRecord.get('foo')).toBe('boo');
+          expect(updatedRecord.get('bar')).toBe('yar');
+        });
+    });
+
+    it('can add the "typecast" parameter when updating one record', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .replace('rec123', {
+          foo: 'boo',
+          bar: 'yar',
+        }, {typecast: true})
+        .then(function (updatedRecord) {
+          expect(updatedRecord.id).toBe('rec123');
+          expect(updatedRecord.get('typecasted')).toBe(true);
+        });
+    });
+
+    it('can update one record with an array', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .replace([{
+          id: 'rec123',
+          fields: {foo: 'boo'},
+        }])
+        .then(function (updatedRecords) {
+          expect(updatedRecords).toHaveLength(1);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('foo')).toBe('boo');
+        });
+    });
+
+    it('can update two records', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .replace([
+          {
+            id: 'rec123',
+            fields: {foo: 'boo'},
+          },
+          {
+            id: 'rec456',
+            fields: {bar: 'yar'},
+          },
+        ])
+        .then(function (updatedRecords) {
+          expect(updatedRecords).toHaveLength(2);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('foo')).toBe('boo');
+          expect(updatedRecords[1].id).toBe('rec456');
+          expect(updatedRecords[1].get('bar')).toBe('yar');
+        });
+    });
+
+    it('can update two records with the "typecast" parameter', function () {
+      return airtable
+        .base('app123')
+        .table('Table')
+        .replace([
+          {
+            id: 'rec123',
+            fields: {foo: 'boo'},
+          },
+          {
+            id: 'rec456',
+            fields: {bar: 'yar'},
+          },
+        ], {typecast: true})
+        .then(function (updatedRecords) {
+          expect(updatedRecords).toHaveLength(2);
+          expect(updatedRecords[0].id).toBe('rec123');
+          expect(updatedRecords[0].get('typecasted')).toBe(true);
+          expect(updatedRecords[1].id).toBe('rec456');
+          expect(updatedRecords[1].get('typecasted')).toBe(true);
+        });
+    });
+  });
+});


### PR DESCRIPTION
**Note: batch record operations are currently beta. Please don't use this for production workflows yet.**

This commit adds support for batch record creation. For example:

```js
const table = airtable.base('app123').table('My Table');
const records = await table.update([
    {
        id: 'rec123',
        fields: {foo: 'boo'},
    },
    {
        id: 'rec456',
        fields: {bar: 'yar'},
    },
]);

console.log(records.length);        // => 2
console.log(records[0].get('foo')); // => 'boo'
console.log(records[1].get('bar')); // => 'yar'

const [clobberedRecord] = await table.replace([{
    id: 'rec456',
    fields: {foo: 'goo'}
}]);
console.log(clobberedRecord.get('foo')); // => 'goo'
console.log(clobberedRecord.get('bar')); // => undefined
```

The `typecast` option works the same as before:

```js
await table.update([/* ... */], {typecast: true});
await table.replace([/* ... */], {typecast: true});
```