### PR TITLE
Test record creation and deletion with callbacks instead of promises

### DIFF
--- a/test/create.test.js
+++ b/test/create.test.js
@@ -32,6 +32,22 @@ describe('record creation', function () {
       });
   });
 
+  it('can create one record and call a callback', function (done) {
+    airtable
+      .base('app123')
+      .table('Table')
+      .create({
+        foo: 'boo',
+        bar: 'yar',
+      }, function (err, createdRecord) {
+        expect(err).toBeNull();
+        expect(createdRecord.id).toBe('rec0');
+        expect(createdRecord.get('foo')).toBe('boo');
+        expect(createdRecord.get('bar')).toBe('yar');
+        done();
+      });
+  });
+
   it('can add the "typecast" parameter when creating one record', function () {
     return airtable
       .base('app123')
@@ -72,6 +88,24 @@ describe('record creation', function () {
         expect(createdRecords[0].get('foo')).toBe('boo');
         expect(createdRecords[1].id).toBe('rec1');
         expect(createdRecords[1].get('bar')).toBe('yar');
+      });
+  });
+
+  it('can create two records and call a callback', function (done) {
+    airtable
+      .base('app123')
+      .table('Table')
+      .create([
+        {foo: 'boo'},
+        {bar: 'yar'},
+      ], function (err, createdRecords) {
+        expect(err).toBeNull();
+        expect(createdRecords).toHaveLength(2);
+        expect(createdRecords[0].id).toBe('rec0');
+        expect(createdRecords[0].get('foo')).toBe('boo');
+        expect(createdRecords[1].id).toBe('rec1');
+        expect(createdRecords[1].get('bar')).toBe('yar');
+        done();
       });
   });
 

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -27,6 +27,17 @@ describe('record deletion', function () {
       });
   });
 
+  it('can delete one record and call a callback', function (done) {
+    airtable
+      .base('app123')
+      .table('Table')
+      .destroy('rec123', function (err, deletedRecord) {
+        expect(err).toBeNull();
+        expect(deletedRecord.id).toBe('rec123');
+        done();
+      });
+  });
+
   it('can delete multiple records', function () {
     return airtable
       .base('app123')
@@ -36,6 +47,20 @@ describe('record deletion', function () {
         expect(deletedRecords).toHaveLength(2);
         expect(deletedRecords[0].id).toBe('rec123');
         expect(deletedRecords[1].id).toBe('rec456');
+      });
+  });
+
+  it('can delete multiple records and call a callback', function (done) {
+    airtable
+      .base('app123')
+      .table('Table')
+      .destroy(['rec123', 'rec456'], function (err, deletedRecords) {
+        expect(err).toBeNull();
+        expect(deletedRecords).toHaveLength(2);
+        expect(deletedRecords).toHaveLength(2);
+        expect(deletedRecords[0].id).toBe('rec123');
+        expect(deletedRecords[1].id).toBe('rec456');
+        done();
       });
   });
 });


### PR DESCRIPTION
Per [a comment on another PR][1], this tests record creation and deletion with callbacks instead of promises.

This only changes tests, which pass with `npm test`.

[1]: https://github.com/Airtable/airtable.js/pull/92/files#r279134648