### PR TITLE
Return `null` instead of `undefined` when checking HTTP status code for error

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -52,6 +52,8 @@ var Base = Class.extend({
                 var message = (body && body.error && body.error.message) ? body.error.message : 'An unexpected error occurred';
                 return new AirtableError(type, message, statusCode);
             })();
+        } else {
+            return null;
         }
     },
 


### PR DESCRIPTION
`Base.prototype._checkStatusForError` implicitly returned `undefined` if no error was returned. This makes it return `null`.