### PR TITLE
Minor: remove unused parameters from record delete callback

### DIFF
--- a/lib/record.js
+++ b/lib/record.js
@@ -67,7 +67,7 @@ var Record = Class.extend({
     },
     destroy: function(done) {
         var that = this;
-        this._table._base.runAction('delete', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, null, function(err, response, results) {
+        this._table._base.runAction('delete', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, null, function(err) {
             if (err) { done(err); return; }
 
             done(null, that);


### PR DESCRIPTION
`response` and `results` aren't used, so we can remove them.