### PR TITLE
Minor: remove unused parameter from firstPage callback

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -44,7 +44,7 @@ var Query = Class.extend({
         assert(isFunction(done),
             'The first parameter to `firstPage` must be a function');
 
-        this.eachPage(function(records, fetchNextPage) {
+        this.eachPage(function(records) {
             done(null, records);
         }, function(error) {
             done(error, null);


### PR DESCRIPTION
`fetchNextPage` wasn't used, so we can remove it.