### PR TITLE
Use lodash function specific packages to decrease package size

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var forEach = require('lodash/forEach');
+var forEach = require('lodash.foreach');
 
 var Class = require('./class');
 var AirtableError = require('./airtable_error');

--- a/lib/object_to_query_param_string.js
+++ b/lib/object_to_query_param_string.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var isArray = require('lodash/isArray');
-var forEach = require('lodash/forEach');
-var isNil = require('lodash/isNil');
-var keys = require('lodash/keys');
+var isArray = require('lodash.isarray');
+var forEach = require('lodash.foreach');
+var isNil = require('lodash.isnil');
+var keys = require('lodash.keys');
 
 // Adapted from jQuery.param:
 // https://github.com/jquery/jquery/blob/2.2-stable/src/serialize.js

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,15 +1,15 @@
 'use strict';
 
 var assert = require('assert');
-var isPlainObject = require('lodash/isPlainObject');
-var isFunction = require('lodash/isFunction');
-var isString = require('lodash/isString');
-var isNumber = require('lodash/isNumber');
-var includes = require('lodash/includes');
-var clone = require('lodash/clone');
-var forEach = require('lodash/forEach');
-var map = require('lodash/map');
-var keys = require('lodash/keys');
+var isPlainObject = require('lodash.isplainobject');
+var isFunction = require('lodash.isfunction');
+var isString = require('lodash.isstring');
+var isNumber = require('lodash.isnumber');
+var includes = require('lodash.includes');
+var clone = require('lodash.clone');
+var forEach = require('lodash.foreach');
+var map = require('lodash.map');
+var keys = require('lodash.keys');
 
 var check = require('./typecheck');
 var Class = require('./class');

--- a/lib/record.js
+++ b/lib/record.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assign = require('lodash/assign');
+var assign = require('lodash.assign');
 
 var Class = require('./class');
 var callbackToPromise = require('./callback_to_promise');

--- a/lib/table.js
+++ b/lib/table.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var isArray = require('lodash/isArray');
-var isPlainObject = require('lodash/isPlainObject');
-var assign = require('lodash/assign');
-var forEach = require('lodash/forEach');
-var map = require('lodash/map');
+var isArray = require('lodash.isarray');
+var isPlainObject = require('lodash.isplainobject');
+var assign = require('lodash.assign');
+var forEach = require('lodash.foreach');
+var map = require('lodash.map');
 
 var assert = require('assert');
 

--- a/lib/typecheck.js
+++ b/lib/typecheck.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var includes = require('lodash/includes');
-var isArray = require('lodash/isArray');
+var includes = require('lodash.includes');
+var isArray = require('lodash.isarray');
 
 function check(fn, error) {
     return function(value) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4785,7 +4785,68 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isarray": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
+      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,18 @@
     "test": "jest --env node"
   },
   "dependencies": {
-    "lodash": "4.17.11",
+    "lodash.assign": "^4.2.0",
+    "lodash.clone": "^4.5.0",
+    "lodash.foreach": "^4.5.0",
+    "lodash.includes": "^4.3.0",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isfunction": "^3.0.9",
+    "lodash.isnil": "^4.0.0",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1",
+    "lodash.keys": "^4.2.0",
+    "lodash.map": "^4.6.0",
     "request": "2.88.0",
     "xhr": "2.3.3"
   },


### PR DESCRIPTION
This replaces the lodash dependency with only the lodash function packages that are necessary for this library to work.

Before change: `2.5MB` compressed or `7MB` uncompressed
After change: `1.9MB` compressed or `5.8MB` uncompressed