### PR TITLE
Remove `assert` module from source

### DIFF
--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var assert = require('assert');
-
 var Class = require('./class');
 var Base = require('./base');
 var Record = require('./record');
@@ -39,7 +37,9 @@ var Airtable = Class.extend({
 
         this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;
 
-        assert(this._apiKey, 'API key is required to connect to Airtable');
+        if (!this._apiKey) {
+            throw new Error('API is required to connect to Airtable');
+        }
     },
 
     base: function(baseId) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var assert = require('assert');
 var isPlainObject = require('lodash/isPlainObject');
 var isFunction = require('lodash/isFunction');
 var isString = require('lodash/isString');
@@ -22,10 +21,15 @@ var Query = Class.extend({
      * or `eachPage` is called.
      */
     init: function(table, params) {
-        assert(isPlainObject(params));
+        if (!isPlainObject(params)) {
+            throw new Error('Expected query options to be an object');
+        }
+
         forEach(keys(params), function(key) {
             var value = params[key];
-            assert(Query.paramValidators[key] && Query.paramValidators[key](value).pass, 'Invalid parameter for Query: ' + key);
+            if (!Query.paramValidators[key] || !Query.paramValidators[key](value).pass) {
+                throw new Error('Invalid parameter for Query: ' + key);
+            }
         });
 
         this._table = table;
@@ -41,8 +45,9 @@ var Query = Class.extend({
      * then calls `done(error, records)`.
      */
     firstPage: function(done) {
-        assert(isFunction(done),
-            'The first parameter to `firstPage` must be a function');
+        if (!isFunction(done)) {
+            throw new Error('The first parameter to `firstPage` must be a function');
+        }
 
         this.eachPage(function(records) {
             done(null, records);
@@ -62,11 +67,13 @@ var Query = Class.extend({
      * `done(error)`.
      */
     eachPage: function(pageCallback, done) {
-        assert(isFunction(pageCallback),
-            'The first parameter to `eachPage` must be a function');
+        if (!isFunction(done)) {
+            throw new Error('The first parameter to `eachPage` must be a function');
+        }
 
-        assert(isFunction(done) || (done === void 0),
-            'The second parameter to `eachPage` must be a function or undefined');
+        if (!isFunction(done) && (done !== void 0)) {
+            throw new Error('The second parameter to `eachPage` must be a function or undefined');
+        }
 
         var that = this;
         var path = '/' + this._table._urlEncodedNameOrId();
@@ -104,8 +111,9 @@ var Query = Class.extend({
      * Fetches all pages of results asynchronously. May take a long time.
      */
     all: function(done) {
-        assert(isFunction(done),
-            'The first parameter to `all` must be a function');
+        if (!isFunction(done)) {
+            throw new Error('The first parameter to `all` must be a function');
+        }
 
         var allRecords = [];
         this.eachPage(function(pageRecords, fetchNextPage) {
@@ -173,7 +181,9 @@ Query.paramValidators = {
  *  errors: a list of error messages.
  */
 Query.validateParams = function validateParams(params) {
-    assert(isPlainObject(params));
+    if (!isPlainObject(params)) {
+        throw new Error('Expected query params to be an object');
+    }
 
     var validParams = {};
     var ignoredKeys = [];

--- a/lib/table.js
+++ b/lib/table.js
@@ -6,8 +6,6 @@ var assign = require('lodash/assign');
 var forEach = require('lodash/forEach');
 var map = require('lodash/map');
 
-var assert = require('assert');
-
 var Class = require('./class');
 var deprecate = require('./deprecate');
 var Query = require('./query');
@@ -16,8 +14,11 @@ var callbackToPromise = require('./callback_to_promise');
 
 var Table = Class.extend({
     init: function(base, tableId, tableName) {
+        if (!tableId && !tableName) {
+            throw new Error('Table name or table ID is required');
+        }
+
         this._base = base;
-        assert(tableId || tableName, 'Table name or table ID is required');
         this.id = tableId;
         this.name = tableName;
 
@@ -60,7 +61,7 @@ var Table = Class.extend({
                     return '  * ' + error;
                 });
 
-                assert(false, 'Airtable: invalid parameters for `select`:\n' +
+                throw new Error('Airtable: invalid parameters for `select`:\n' +
                     formattedErrors.join('\n'));
             }
 
@@ -71,7 +72,7 @@ var Table = Class.extend({
 
             return new Query(this, validationResults.validParams);
         } else {
-            assert(false, 'Airtable: the parameter for `select` should be a plain object or undefined.');
+            throw new Error('Airtable: the parameter for `select` should be a plain object or undefined.');
         }
     },
     _urlEncodedNameOrId: function(){


### PR DESCRIPTION
This removes the `assert` module from source and replaces it with `if (...) { throw new Error(...) }`. This has a few benefits:

* When we switch ESLint, some of our code will error because we [don't have consistent returns][1] in some of our functions. This fixes those issues to ease the transition.
* Reduces the size of the browser build because we don't need to include the `assert` module. Shaves off 12 KB from the minified build (from 72,458 bytes to 60,0280).
* Though Browserify shims the `assert` module just fine, it removes a subtle difference between the browser build and Node.

This is arguably a breaking change because we're now throwing regular `Error`s instead of `assert.AssertionError`s, but I would argue that this is safe.

[1]: https://eslint.org/docs/rules/consistent-return