### PR TITLE
Nest batch-created record values under "fields"

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -88,11 +88,7 @@ var Table = Class.extend({
         }
         var requestData;
         if (isCreatingMultipleRecords) {
-            requestData = {
-                records: recordsData.map(function (fields) {
-                    return {fields: fields};
-                }),
-            };
+            requestData = {records: recordsData};
         } else {
             requestData = {fields: recordsData};
         }

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -66,7 +66,9 @@ describe('record creation', function () {
     return airtable
       .base('app123')
       .table('Table')
-      .create([{foo: 'boo'}])
+      .create([{
+        fields: {foo: 'boo'}
+      }])
       .then(function (createdRecords) {
         expect(createdRecords).toHaveLength(1);
         expect(createdRecords[0].id).toBe('rec0');
@@ -79,8 +81,8 @@ describe('record creation', function () {
       .base('app123')
       .table('Table')
       .create([
-        {foo: 'boo'},
-        {bar: 'yar'},
+        {fields: {foo: 'boo'}},
+        {fields: {bar: 'yar'}},
       ])
       .then(function (createdRecords) {
         expect(createdRecords).toHaveLength(2);
@@ -96,8 +98,8 @@ describe('record creation', function () {
       .base('app123')
       .table('Table')
       .create([
-        {foo: 'boo'},
-        {bar: 'yar'},
+        {fields: {foo: 'boo'}},
+        {fields: {bar: 'yar'}},
       ], function (err, createdRecords) {
         expect(err).toBeNull();
         expect(createdRecords).toHaveLength(2);
@@ -114,8 +116,8 @@ describe('record creation', function () {
       .base('app123')
       .table('Table')
       .create([
-        {foo: 'boo'},
-        {bar: 'yar'},
+        {fields: {foo: 'boo'}},
+        {fields: {bar: 'yar'}},
       ], {typecast: true})
       .then(function (createdRecords) {
         expect(createdRecords).toHaveLength(2);


### PR DESCRIPTION
**Note: batch record operations are currently beta. Please don't use this for production workflows yet.**

Before:

```js
await myTable.create([
  {foo: 'boo'},
  {foo: 'bar'},
])
```

After:

```js
await myTable.create([
  {fields: {foo: 'boo'}},
  {fields: {foo: 'bar'}},
])
```

As a side-effect of this change, we stopped calling `Array.prototype.map`, which may not be available in older browsers.