### PR TITLE
Fix incorrect assertion check

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -67,7 +67,7 @@ var Query = Class.extend({
      * `done(error)`.
      */
     eachPage: function(pageCallback, done) {
-        if (!isFunction(done)) {
+        if (!isFunction(pageCallback)) {
             throw new Error('The first parameter to `eachPage` must be a function');
         }
 


### PR DESCRIPTION
8182446bfac6c55a4016255cfc86e6748ab88e41 introduced a regression. Here's the relevant part of that diff:

```diff
- assert(isFunction(pageCallback),
-     'The first parameter to `eachPage` must be a function');
+ if (!isFunction(done)) {
+     throw new Error('The first parameter to `eachPage` must be a function');
+ }
```

This should have been checking whether `pageCallback` was a function but instead changed to `done`.

I re-reviewed the original commit and didn't see any other mistakes.