### PR TITLE
Return consistently in callbackToPromise

### DIFF
--- a/lib/callback_to_promise.js
+++ b/lib/callback_to_promise.js
@@ -17,6 +17,7 @@ function callbackToPromise(fn, context, callbackArgIndex) {
         var callbackArg = arguments[thisCallbackArgIndex];
         if (typeof callbackArg === 'function') {
             fn.apply(context, arguments);
+            return;
         } else {
             var args = [];
             // If an explicit callbackArgIndex is set, but the function is called


### PR DESCRIPTION
When we switch to ESLint, `callbackToPromise` will give a [`consistent-return`][1] error because we don't have a consistent return. This fixes that.

It shouldn't change the behavior of the function at all.

[1]: http://eslint.org/docs/rules/consistent-return