### PR TITLE
Clarify error message for missing api key

### DIFF
--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -38,7 +38,7 @@ var Airtable = Class.extend({
         this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;
 
         if (!this._apiKey) {
-            throw new Error('API is required to connect to Airtable');
+            throw new Error('API Key is required to connect to Airtable');
         }
     },
 

--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -38,7 +38,7 @@ var Airtable = Class.extend({
         this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;
 
         if (!this._apiKey) {
-            throw new Error('API Key is required to connect to Airtable');
+            throw new Error('An API key is required to connect to Airtable');
         }
     },
 


### PR DESCRIPTION
If you accidentally make a request with a missing api key, error message is ambiguous.

```javascript
// where process.env.AIRTABLE_KEY = null (unset variable)
Airtable.configure({
  endpointUrl: 'https://api.airtable.com',
  apiKey: process.env.AIRTABLE_KEY
})
...
``` 

Results in the error:
```
Error: API is required to connect to Airtable
```

I had forgotten to set the env var, so I was scratching my head to figure out what `API is required` meant. I think It would be more helpful if it instead described: 
```
Error: API Key is required to connect to Airtable
```