### PR TITLE
Minor: remove unused variable from query params utility

### DIFF
--- a/lib/object_to_query_param_string.js
+++ b/lib/object_to_query_param_string.js
@@ -7,7 +7,6 @@ var isNil = require('lodash/isNil');
 // Adapted from jQuery.param:
 // https://github.com/jquery/jquery/blob/2.2-stable/src/serialize.js
 function buildParams(prefix, obj, addFn) {
-    var name;
     if (isArray(obj)) {
         // Serialize array item.
         forEach(obj, function(value, index) {


### PR DESCRIPTION
ESLint is the main motivation for this change, where this unused variable will issue a warning.