### PR TITLE
Minor: remove unnecessary block in tests

### DIFF
--- a/test/object_to_query_param_string.test.js
+++ b/test/object_to_query_param_string.test.js
@@ -51,20 +51,18 @@ describe('objectToQueryParamString', function () {
 
         expect(objectToQueryParamString({arr: []})).toBe('');
 
-        {
-            var actual = querystring.parse(objectToQueryParamString({
-                arr: [
-                    {foo: 'boo'},
-                    {foo: 'bar', baz: 'qux'},
-                ],
-            }));
-            var expected = {
-                'arr[0][foo]': 'boo',
-                'arr[1][foo]': 'bar',
-                'arr[1][baz]': 'qux',
-            };
-            expect(actual).toEqual(expected);
-        }
+        var actual = querystring.parse(objectToQueryParamString({
+            arr: [
+                {foo: 'boo'},
+                {foo: 'bar', baz: 'qux'},
+            ],
+        }));
+        var expected = {
+            'arr[0][foo]': 'boo',
+            'arr[1][foo]': 'bar',
+            'arr[1][baz]': 'qux',
+        };
+        expect(actual).toEqual(expected);
     });
 
     it('serializes objects', function () {


### PR DESCRIPTION
ESLint is the main motivation for this change, which will issue an error from [the `no-lone-blocks` rule][1].

[1]: https://eslint.org/docs/rules/no-lone-blocks