### PR TITLE
Minor: use `Object.prototype.hasOwnProperty` instead of calling `hasOwnProperty` on an object

### DIFF
--- a/lib/has.js
+++ b/lib/has.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function has(object, property) {
+    return Object.prototype.hasOwnProperty.call(object, property);
+}
+
+module.exports = has;

--- a/lib/query.js
+++ b/lib/query.js
@@ -14,6 +14,7 @@ var check = require('./typecheck');
 var Class = require('./class');
 var Record = require('./record');
 var callbackToPromise = require('./callback_to_promise');
+var has = require('./has');
 
 var Query = Class.extend({
     /**
@@ -191,7 +192,7 @@ Query.validateParams = function validateParams(params) {
 
     forEach(keys(params), function(key) {
         var value = params[key];
-        if (Query.paramValidators.hasOwnProperty(key)) {
+        if (has(Query.paramValidators, key)) {
             var validator = Query.paramValidators[key];
             var validationResult = validator(value);
             if (validationResult.pass) {

--- a/test/has.test.js
+++ b/test/has.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var has = require('../lib/has');
+
+describe('has', function() {
+    it('returns true if the object has the property as an own property, false otherwise', function() {
+        expect(has({}, 'foo')).toBe(false);
+        expect(has({}, 'hasOwnProperty')).toBe(false);
+
+        expect(has({foo: void 0}, 'foo')).toBe(true);
+        expect(has({foo: void 0}, 'boo')).toBe(false);
+        expect(has({foo: void 0}, 'hasOwnProperty')).toBe(false);
+    });
+
+    it('works even if the object has a property called "hasOwnProperty"', function() {
+        expect(has({hasOwnProperty: 123}, 'hasOwnProperty')).toBe(true); // jshint ignore:line
+    });
+});


### PR DESCRIPTION
ESLint will complain about the line in `lib/query.js`, so I replaced it with a new `has` utility.