### PR TITLE
Update Lodash to 4.17.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4927,9 +4927,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --env node"
   },
   "dependencies": {
-    "lodash": "4.17.11",
+    "lodash": "4.17.14",
     "request": "2.88.0",
     "xhr": "2.3.3"
   },


### PR DESCRIPTION
Older Lodash versions have a [security vulnerability][1] in the `defaultsDeep` function. We weren't using this function directly, but this update also updates all of our sub-dependencies using Lodash (for example, Jest depends on Lodash).

[1]: https://github.com/lodash/lodash/pull/4336