### PR TITLE
Stop publishing non-essential files (like tests and gruntfile) to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
   "browser": {
     "request": "xhr"
   },
+  "files": [
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE.txt",
+    "/build/airtable.browser.js",
+    "/lib/"
+  ],
   "devDependencies": {
     "body-parser": "^1.19.0",
     "envify": "^4.1.0",


### PR DESCRIPTION
I noticed that we were publishing a bunch of unnecessary files (like the `test` directory and `gruntfile.js`) to npm. At best, this wastes space. At worst, we could accidentally publish some sensitive file (though that's unlikely).

Tested this by:

1. Ran `npm pack` and verified that no unnecessary files were included
2. Copied the resulting tarball, `airtable-0.7.0.tgz`, into a temporary directory
3. Ran `npm i airtable-0.7.0.tgz`
4. Verified that `node -p "require('airtable')"` didn't break

See documentation for the [`files`][1] key in `package.json` for more info here.

[1]: https://docs.npmjs.com/files/package.json#files