### PR TITLE
Properly reject unauthorized certificates

### DIFF
--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -43,7 +43,7 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         headers: headers,
         // agentOptions are ignored when running in the browser.
         agentOptions: {
-            rejectUnauthorized: base._airtable._allowUnauthorizedSsl
+            rejectUnauthorized: !base._airtable._allowUnauthorizedSsl
         },
     };
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -30,7 +30,7 @@ describe('Base', function() {
                     'User-Agent': 'Airtable.js/' + version
                 },
                 agentOptions: {
-                    rejectUnauthorized: false
+                    rejectUnauthorized: true
                 }
             }, expect.any(Function));
 


### PR DESCRIPTION
We only want Airtable.js to connect to servers with authorized SSL certificates, at least by default.

Before this change, we weren't doing that. By default, this library would connect to a site with an unauthorized SSL certificate by default. (Confusingly, you could fix this by setting the undocumented `allowUnauthorizedSsl` option to `false`, which is backwards!)

This change fixes that. Now the `allowUnauthorizedSsl` option works as expected, and more importantly, we will reject unauthorized certificates by default.