### PR TITLE
Update Lodash to 4.17.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4961,9 +4961,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --env node"
   },
   "dependencies": {
-    "lodash": "4.17.14",
+    "lodash": "4.17.15",
     "request": "2.88.0",
     "xhr": "2.3.3"
   },


### PR DESCRIPTION
According to the [Lodash changelog][1], this shouldn't do much other than shrink the size of the installation.

Given that we're about to do a version bump, I think it'd be nice to do now.

[1]: https://github.com/lodash/lodash/wiki/Changelog