### PR TITLE
Add `npm run format` to run Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+/build/
+/test/test_files/
+/node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+    "singleQuote": true,
+    "endOfLine": "lf",
+    "trailingComma": "es5",
+    "bracketSpacing": false,
+    "tabWidth": 4,
+    "printWidth": 100,
+    "proseWrap": "always"
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -12,16 +12,19 @@ module.exports = function(grunt) {
                 dest: './build/airtable.browser.js',
                 options: {
                     transform: [
-                        ['envify', {
-                            _: 'purge',
-                            npm_package_version: pkg.version,
-                        }]
+                        [
+                            'envify',
+                            {
+                                _: 'purge',
+                                npm_package_version: pkg.version,
+                            },
+                        ],
                     ],
                     preBundleCB: function(b) {
                         b.require('./lib/airtable.js', {expose: 'airtable'});
-                    }
-                }
-            }
+                    },
+                },
+            },
         },
     });
 

--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -26,10 +26,16 @@ function Airtable(opts) {
             value: apiVersion.split('.')[0],
         },
         _allowUnauthorizedSsl: {
-            value: opts.allowUnauthorizedSsl || Airtable.allowUnauthorizedSsl || defaultConfig.allowUnauthorizedSsl,
+            value:
+                opts.allowUnauthorizedSsl ||
+                Airtable.allowUnauthorizedSsl ||
+                defaultConfig.allowUnauthorizedSsl,
         },
         _noRetryIfRateLimited: {
-            value: opts.noRetryIfRateLimited || Airtable.noRetryIfRateLimited || defaultConfig.noRetryIfRateLimited,
+            value:
+                opts.noRetryIfRateLimited ||
+                Airtable.noRetryIfRateLimited ||
+                defaultConfig.noRetryIfRateLimited,
         },
     });
 

--- a/lib/airtable_error.js
+++ b/lib/airtable_error.js
@@ -9,8 +9,10 @@ function AirtableError(error, message, statusCode) {
 AirtableError.prototype.toString = function() {
     return [
         this.message,
-        '(', this.error, ')',
-        this.statusCode ? '[Http code ' + this.statusCode + ']' : ''
+        '(',
+        this.error,
+        ')',
+        this.statusCode ? '[Http code ' + this.statusCode + ']' : '',
     ].join('');
 };
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -21,32 +21,62 @@ Base.prototype.runAction = function(method, path, queryParams, bodyData, callbac
 
 Base.prototype._checkStatusForError = function(statusCode, body) {
     if (statusCode === 401) {
-        return new AirtableError('AUTHENTICATION_REQUIRED', 'You should provide valid api key to perform this operation', statusCode);
+        return new AirtableError(
+            'AUTHENTICATION_REQUIRED',
+            'You should provide valid api key to perform this operation',
+            statusCode
+        );
     } else if (statusCode === 403) {
-        return new AirtableError('NOT_AUTHORIZED', 'You are not authorized to perform this operation', statusCode);
+        return new AirtableError(
+            'NOT_AUTHORIZED',
+            'You are not authorized to perform this operation',
+            statusCode
+        );
     } else if (statusCode === 404) {
         return (function() {
-            var message = (body && body.error && body.error.message) ? body.error.message : 'Could not find what you are looking for';
+            var message =
+                body && body.error && body.error.message
+                    ? body.error.message
+                    : 'Could not find what you are looking for';
             return new AirtableError('NOT_FOUND', message, statusCode);
         })();
     } else if (statusCode === 413) {
         return new AirtableError('REQUEST_TOO_LARGE', 'Request body is too large', statusCode);
     } else if (statusCode === 422) {
         return (function() {
-            var type = (body && body.error && body.error.type) ? body.error.type : 'UNPROCESSABLE_ENTITY';
-            var message = (body && body.error && body.error.message) ? body.error.message : 'The operation cannot be processed';
+            var type =
+                body && body.error && body.error.type ? body.error.type : 'UNPROCESSABLE_ENTITY';
+            var message =
+                body && body.error && body.error.message
+                    ? body.error.message
+                    : 'The operation cannot be processed';
             return new AirtableError(type, message, statusCode);
         })();
     } else if (statusCode === 429) {
-        return new AirtableError('TOO_MANY_REQUESTS', 'You have made too many requests in a short period of time. Please retry your request later', statusCode);
+        return new AirtableError(
+            'TOO_MANY_REQUESTS',
+            'You have made too many requests in a short period of time. Please retry your request later',
+            statusCode
+        );
     } else if (statusCode === 500) {
-        return new AirtableError('SERVER_ERROR', 'Try again. If the problem persists, contact support.', statusCode);
+        return new AirtableError(
+            'SERVER_ERROR',
+            'Try again. If the problem persists, contact support.',
+            statusCode
+        );
     } else if (statusCode === 503) {
-        return new AirtableError('SERVICE_UNAVAILABLE', 'The service is temporarily unavailable. Please retry shortly.', statusCode);
+        return new AirtableError(
+            'SERVICE_UNAVAILABLE',
+            'The service is temporarily unavailable. Please retry shortly.',
+            statusCode
+        );
     } else if (statusCode >= 400) {
         return (function() {
-            var type = (body && body.error && body.error.type) ? body.error.type : 'UNEXPECTED_ERROR';
-            var message = (body && body.error && body.error.message) ? body.error.message : 'An unexpected error occurred';
+            var type = body && body.error && body.error.type ? body.error.type : 'UNEXPECTED_ERROR';
+            var message =
+                body && body.error && body.error.message
+                    ? body.error.message
+                    : 'An unexpected error occurred';
             return new AirtableError(type, message, statusCode);
         })();
     } else {

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -24,4 +24,3 @@ function deprecate(fn, key, message) {
 }
 
 module.exports = deprecate;
-

--- a/lib/query.js
+++ b/lib/query.js
@@ -48,11 +48,14 @@ function firstPage(done) {
         throw new Error('The first parameter to `firstPage` must be a function');
     }
 
-    this.eachPage(function(records) {
-        done(null, records);
-    }, function(error) {
-        done(error, null);
-    });
+    this.eachPage(
+        function(records) {
+            done(null, records);
+        },
+        function(error) {
+            done(error, null);
+        }
+    );
 }
 
 /**
@@ -70,7 +73,7 @@ function eachPage(pageCallback, done) {
         throw new Error('The first parameter to `eachPage` must be a function');
     }
 
-    if (!isFunction(done) && (done !== void 0)) {
+    if (!isFunction(done) && done !== void 0) {
         throw new Error('The second parameter to `eachPage` must be a function or undefined');
     }
 
@@ -116,59 +119,55 @@ function all(done) {
     }
 
     var allRecords = [];
-    this.eachPage(function(pageRecords, fetchNextPage) {
-        allRecords.push.apply(allRecords, pageRecords);
-        fetchNextPage();
-    }, function(err) {
-        if (err) {
-            done(err, null);
-        } else {
-            done(null, allRecords);
+    this.eachPage(
+        function(pageRecords, fetchNextPage) {
+            allRecords.push.apply(allRecords, pageRecords);
+            fetchNextPage();
+        },
+        function(err) {
+            if (err) {
+                done(err, null);
+            } else {
+                done(null, allRecords);
+            }
         }
-    });
+    );
 }
 
 Query.paramValidators = {
-    fields:
-        check(check.isArrayOf(isString), 'the value for `fields` should be an array of strings'),
+    fields: check(
+        check.isArrayOf(isString),
+        'the value for `fields` should be an array of strings'
+    ),
 
-    filterByFormula:
-        check(isString, 'the value for `filterByFormula` should be a string'),
+    filterByFormula: check(isString, 'the value for `filterByFormula` should be a string'),
 
-    maxRecords:
-        check(isNumber, 'the value for `maxRecords` should be a number'),
+    maxRecords: check(isNumber, 'the value for `maxRecords` should be a number'),
 
-    pageSize:
-        check(isNumber, 'the value for `pageSize` should be a number'),
+    pageSize: check(isNumber, 'the value for `pageSize` should be a number'),
 
-    sort:
-        check(check.isArrayOf(function(obj) {
+    sort: check(
+        check.isArrayOf(function(obj) {
             return (
                 isPlainObject(obj) &&
                 isString(obj.field) &&
-                ((obj.direction === void 0) || includes(['asc', 'desc'], obj.direction))
+                (obj.direction === void 0 || includes(['asc', 'desc'], obj.direction))
             );
-        }), 'the value for `sort` should be an array of sort objects. ' +
+        }),
+        'the value for `sort` should be an array of sort objects. ' +
             'Each sort object must have a string `field` value, and an optional ' +
             '`direction` value that is "asc" or "desc".'
-        ),
+    ),
 
-    view:
-        check(isString, 'the value for `view` should be a string'),
+    view: check(isString, 'the value for `view` should be a string'),
 
-    cellFormat:
-        check(function(cellFormat) {
-            return (
-                isString(cellFormat) &&
-                includes(['json', 'string'], cellFormat)
-            );
-        }, 'the value for `cellFormat` should be "json" or "string"'),
+    cellFormat: check(function(cellFormat) {
+        return isString(cellFormat) && includes(['json', 'string'], cellFormat);
+    }, 'the value for `cellFormat` should be "json" or "string"'),
 
-    timeZone:
-        check(isString, 'the value for `timeZone` should be a string'),
+    timeZone: check(isString, 'the value for `timeZone` should be a string'),
 
-    userLocale:
-        check(isString, 'the value for `userLocale` should be a string'),
+    userLocale: check(isString, 'the value for `userLocale` should be a string'),
 };
 
 /**

--- a/lib/record.js
+++ b/lib/record.js
@@ -41,16 +41,28 @@ function patchUpdate(cellValuesByName, opts, done) {
         done = opts;
         opts = {};
     }
-    var updateBody = assign({
-        fields: cellValuesByName
-    }, opts);
+    var updateBody = assign(
+        {
+            fields: cellValuesByName,
+        },
+        opts
+    );
 
-    this._table._base.runAction('patch', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, updateBody, function(err, response, results) {
-        if (err) { done(err); return; }
+    this._table._base.runAction(
+        'patch',
+        '/' + this._table._urlEncodedNameOrId() + '/' + this.id,
+        {},
+        updateBody,
+        function(err, response, results) {
+            if (err) {
+                done(err);
+                return;
+            }
 
-        that.setRawJson(results);
-        done(null, that);
-    });
+            that.setRawJson(results);
+            done(null, that);
+        }
+    );
 }
 
 function putUpdate(cellValuesByName, opts, done) {
@@ -59,34 +71,64 @@ function putUpdate(cellValuesByName, opts, done) {
         done = opts;
         opts = {};
     }
-    var updateBody = assign({
-        fields: cellValuesByName
-    }, opts);
-    this._table._base.runAction('put', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, updateBody, function(err, response, results) {
-        if (err) { done(err); return; }
+    var updateBody = assign(
+        {
+            fields: cellValuesByName,
+        },
+        opts
+    );
+    this._table._base.runAction(
+        'put',
+        '/' + this._table._urlEncodedNameOrId() + '/' + this.id,
+        {},
+        updateBody,
+        function(err, response, results) {
+            if (err) {
+                done(err);
+                return;
+            }
 
-        that.setRawJson(results);
-        done(null, that);
-    });
+            that.setRawJson(results);
+            done(null, that);
+        }
+    );
 }
 
 function destroy(done) {
     var that = this;
-    this._table._base.runAction('delete', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, null, function(err) {
-        if (err) { done(err); return; }
+    this._table._base.runAction(
+        'delete',
+        '/' + this._table._urlEncodedNameOrId() + '/' + this.id,
+        {},
+        null,
+        function(err) {
+            if (err) {
+                done(err);
+                return;
+            }
 
-        done(null, that);
-    });
+            done(null, that);
+        }
+    );
 }
 
 function fetch(done) {
     var that = this;
-    this._table._base.runAction('get', '/' + this._table._urlEncodedNameOrId() + '/' + this.id, {}, null, function(err, response, results) {
-        if (err) { done(err); return; }
+    this._table._base.runAction(
+        'get',
+        '/' + this._table._urlEncodedNameOrId() + '/' + this.id,
+        {},
+        null,
+        function(err, response, results) {
+            if (err) {
+                done(err);
+                return;
+            }
 
-        that.setRawJson(results);
-        done(null, that);
-    });
+            that.setRawJson(results);
+            done(null, that);
+        }
+    );
 }
 
 Record.prototype.setRawJson = function(rawJson) {

--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -18,10 +18,18 @@ function exponentialBackoffWithJitter(numberOfRetries, initialBackoffTimeMs, max
 }
 
 function runAction(base, method, path, queryParams, bodyData, callback, numAttempts) {
-    var url = base._airtable._endpointUrl + '/v' + base._airtable._apiVersionMajor + '/' + base._id + path + '?' + objectToQueryParamString(queryParams);
+    var url =
+        base._airtable._endpointUrl +
+        '/v' +
+        base._airtable._apiVersionMajor +
+        '/' +
+        base._id +
+        path +
+        '?' +
+        objectToQueryParamString(queryParams);
 
     var headers = {
-        'authorization': 'Bearer ' + base._airtable._apiKey,
+        authorization: 'Bearer ' + base._airtable._apiKey,
         'x-api-version': base._airtable._apiVersion,
         'x-airtable-application-id': base.getId(),
     };
@@ -34,7 +42,6 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         headers['User-Agent'] = userAgent;
     }
 
-
     var options = {
         method: method.toUpperCase(),
         url: url,
@@ -43,7 +50,7 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         headers: headers,
         // agentOptions are ignored when running in the browser.
         agentOptions: {
-            rejectUnauthorized: !base._airtable._allowUnauthorizedSsl
+            rejectUnauthorized: !base._airtable._allowUnauthorizedSsl,
         },
     };
 
@@ -58,7 +65,11 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         }
 
         if (resp.statusCode === 429 && !base._airtable._noRetryIfRateLimited) {
-            var backoffDelayMs = exponentialBackoffWithJitter(numAttempts, internalConfig.INITIAL_RETRY_DELAY_IF_RATE_LIMITED, internalConfig.MAX_RETRY_DELAY_IF_RATE_LIMITED);
+            var backoffDelayMs = exponentialBackoffWithJitter(
+                numAttempts,
+                internalConfig.INITIAL_RETRY_DELAY_IF_RATE_LIMITED,
+                internalConfig.MAX_RETRY_DELAY_IF_RATE_LIMITED
+            );
             setTimeout(function() {
                 runAction(base, method, path, queryParams, bodyData, callback, numAttempts + 1);
             }, backoffDelayMs);

--- a/lib/table.js
+++ b/lib/table.js
@@ -29,12 +29,16 @@ function Table(base, tableId, tableName) {
     this.destroy = callbackToPromise(this._destroyRecord, this);
 
     // Deprecated API
-    this.list = deprecate(this._listRecords.bind(this),
+    this.list = deprecate(
+        this._listRecords.bind(this),
         'table.list',
-        'Airtable: `list()` is deprecated. Use `select()` instead.');
-    this.forEach = deprecate(this._forEachRecord.bind(this),
+        'Airtable: `list()` is deprecated. Use `select()` instead.'
+    );
+    this.forEach = deprecate(
+        this._forEachRecord.bind(this),
         'table.forEach',
-        'Airtable: `forEach()` is deprecated. Use `select()` instead.');
+        'Airtable: `forEach()` is deprecated. Use `select()` instead.'
+    );
 }
 
 Table.prototype._findRecordById = function(recordId, done) {
@@ -48,9 +52,12 @@ Table.prototype._selectRecords = function(params) {
     }
 
     if (arguments.length > 1) {
-        console.warn('Airtable: `select` takes only one parameter, but it was given ' +
-                arguments.length + ' parameters. ' +
-                'Use `eachPage` or `firstPage` to fetch records.');
+        console.warn(
+            'Airtable: `select` takes only one parameter, but it was given ' +
+                arguments.length +
+                ' parameters. ' +
+                'Use `eachPage` or `firstPage` to fetch records.'
+        );
     }
 
     if (isPlainObject(params)) {
@@ -61,18 +68,23 @@ Table.prototype._selectRecords = function(params) {
                 return '  * ' + error;
             });
 
-            throw new Error('Airtable: invalid parameters for `select`:\n' +
-                    formattedErrors.join('\n'));
+            throw new Error(
+                'Airtable: invalid parameters for `select`:\n' + formattedErrors.join('\n')
+            );
         }
 
         if (validationResults.ignoredKeys.length) {
-            console.warn('Airtable: the following parameters to `select` will be ignored: ' +
-                    validationResults.ignoredKeys.join(', '));
+            console.warn(
+                'Airtable: the following parameters to `select` will be ignored: ' +
+                    validationResults.ignoredKeys.join(', ')
+            );
         }
 
         return new Query(this, validationResults.validParams);
     } else {
-        throw new Error('Airtable: the parameter for `select` should be a plain object or undefined.');
+        throw new Error(
+            'Airtable: the parameter for `select` should be a plain object or undefined.'
+        );
     }
 };
 
@@ -95,8 +107,15 @@ Table.prototype._createRecords = function(recordsData, optionalParameters, done)
         requestData = {fields: recordsData};
     }
     assign(requestData, optionalParameters);
-    this._base.runAction('post', '/' + that._urlEncodedNameOrId() + '/', {}, requestData, function(err, resp, body) {
-        if (err) { done(err); return; }
+    this._base.runAction('post', '/' + that._urlEncodedNameOrId() + '/', {}, requestData, function(
+        err,
+        resp,
+        body
+    ) {
+        if (err) {
+            done(err);
+            return;
+        }
 
         var result;
         if (isCreatingMultipleRecords) {
@@ -110,7 +129,13 @@ Table.prototype._createRecords = function(recordsData, optionalParameters, done)
     });
 };
 
-Table.prototype._updateRecords = function(isDestructiveUpdate, recordsDataOrRecordId, recordDataOrOptsOrDone, optsOrDone, done) {
+Table.prototype._updateRecords = function(
+    isDestructiveUpdate,
+    recordsDataOrRecordId,
+    recordDataOrOptsOrDone,
+    optsOrDone,
+    done
+) {
     var opts;
 
     if (isArray(recordsDataOrRecordId)) {
@@ -121,14 +146,23 @@ Table.prototype._updateRecords = function(isDestructiveUpdate, recordsDataOrReco
 
         var method = isDestructiveUpdate ? 'put' : 'patch';
         var requestData = assign({records: recordsData}, opts);
-        this._base.runAction(method, '/' + this._urlEncodedNameOrId() + '/', {}, requestData, function(err, resp, body) {
-            if (err) { done(err); return; }
+        this._base.runAction(
+            method,
+            '/' + this._urlEncodedNameOrId() + '/',
+            {},
+            requestData,
+            function(err, resp, body) {
+                if (err) {
+                    done(err);
+                    return;
+                }
 
-            var result = body.records.map(function(record) {
-                return new Record(that, record.id, record);
-            });
-            done(null, result);
-        });
+                var result = body.records.map(function(record) {
+                    return new Record(that, record.id, record);
+                });
+                done(null, result);
+            }
+        );
     } else {
         var recordId = recordsDataOrRecordId;
         var recordData = recordDataOrOptsOrDone;
@@ -148,17 +182,23 @@ Table.prototype._destroyRecord = function(recordIdsOrId, done) {
     if (isArray(recordIdsOrId)) {
         var that = this;
         var queryParams = {records: recordIdsOrId};
-        this._base.runAction('delete', '/' + this._urlEncodedNameOrId(), queryParams, null, function(err, response, results) {
-            if (err) {
-                done(err);
-                return;
-            }
+        this._base.runAction(
+            'delete',
+            '/' + this._urlEncodedNameOrId(),
+            queryParams,
+            null,
+            function(err, response, results) {
+                if (err) {
+                    done(err);
+                    return;
+                }
 
-            var records = map(results.records, function(recordJson) {
-                return new Record(that, recordJson.id, null);
-            });
-            done(null, records);
-        });
+                var records = map(results.records, function(recordJson) {
+                    return new Record(that, recordJson.id, null);
+                });
+                done(null, records);
+            }
+        );
     } else {
         var record = new Record(this, recordIdsOrId);
         record.destroy(done);
@@ -172,21 +212,31 @@ Table.prototype._listRecords = function(limit, offset, opts, done) {
         done = opts;
         opts = {};
     }
-    var listRecordsParameters = assign({
-        limit: limit, offset: offset
-    }, opts);
+    var listRecordsParameters = assign(
+        {
+            limit: limit,
+            offset: offset,
+        },
+        opts
+    );
 
-    this._base.runAction('get', '/' + this._urlEncodedNameOrId() + '/', listRecordsParameters, null, function(err, response, results) {
-        if (err) {
-            done(err);
-            return;
+    this._base.runAction(
+        'get',
+        '/' + this._urlEncodedNameOrId() + '/',
+        listRecordsParameters,
+        null,
+        function(err, response, results) {
+            if (err) {
+                done(err);
+                return;
+            }
+
+            var records = map(results.records, function(recordJson) {
+                return new Record(that, null, recordJson);
+            });
+            done(null, records, results.offset);
         }
-
-        var records = map(results.records, function(recordJson) {
-            return new Record(that, null, recordJson);
-        });
-        done(null, records, results.offset);
-    });
+    );
 };
 
 Table.prototype._forEachRecord = function(opts, callback, done) {
@@ -201,7 +251,10 @@ Table.prototype._forEachRecord = function(opts, callback, done) {
 
     var nextPage = function() {
         that._listRecords(limit, offset, opts, function(err, page, newOffset) {
-            if (err) { done(err); return; }
+            if (err) {
+                done(err);
+                return;
+            }
 
             forEach(page, callback);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1492,6 +1492,12 @@
         "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -5194,6 +5200,12 @@
         "mime-db": "~1.36.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -5549,7 +5561,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -5863,6 +5875,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "pretty-format": {
@@ -6846,33 +6864,6 @@
         }
       }
     },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "string.prototype.trimleft": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
@@ -7701,6 +7692,12 @@
         "strip-ansi": "^5.0.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -7795,6 +7792,12 @@
         "yargs-parser": "^13.1.1"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "pretest": "npm run lint",
     "lint": "eslint .",
+    "format": "prettier --write '**/*.js'",
     "test": "jest --env node"
   },
   "dependencies": {
@@ -35,7 +36,8 @@
     "get-port": "^5.0.0",
     "grunt": "^1.0.4",
     "grunt-browserify": "^5.3.0",
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "prettier": "^1.18.2"
   },
   "keywords": [
     "airtable",

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -11,28 +11,31 @@ describe('Base', function() {
         it('makes requests with the right options', function() {
             var fakeAirtable = new Airtable({
                 apiKey: 'keyXyz',
-                requestTimeout: 1234
+                requestTimeout: 1234,
             });
             var fakeBase = fakeAirtable.base('app123');
 
             fakeBase.runAction('get', '/my_table/rec456', {}, null, function() {});
 
             expect(request).toHaveBeenCalledTimes(1);
-            expect(request).toHaveBeenCalledWith({
-                method: 'GET',
-                url: 'https://api.airtable.com/v0/app123/my_table/rec456?',
-                json: true,
-                timeout: 1234,
-                headers: {
-                    authorization: 'Bearer keyXyz',
-                    'x-api-version': '0.1.0',
-                    'x-airtable-application-id': 'app123',
-                    'User-Agent': 'Airtable.js/' + version
+            expect(request).toHaveBeenCalledWith(
+                {
+                    method: 'GET',
+                    url: 'https://api.airtable.com/v0/app123/my_table/rec456?',
+                    json: true,
+                    timeout: 1234,
+                    headers: {
+                        authorization: 'Bearer keyXyz',
+                        'x-api-version': '0.1.0',
+                        'x-airtable-application-id': 'app123',
+                        'User-Agent': 'Airtable.js/' + version,
+                    },
+                    agentOptions: {
+                        rejectUnauthorized: true,
+                    },
                 },
-                agentOptions: {
-                    rejectUnauthorized: true
-                }
-            }, expect.any(Function));
+                expect.any(Function)
+            );
 
             expect(version).toEqual(expect.stringMatching(/^\d+\.\d+\.\d+$/));
         });

--- a/test/browser_build.test.js
+++ b/test/browser_build.test.js
@@ -13,10 +13,7 @@ describe('browser build', function() {
                 return;
             }
 
-            var exceptions = [
-                /process\.env\.NODE_DEBUG/,
-                /process\.env = {}/
-            ];
+            var exceptions = [/process\.env\.NODE_DEBUG/, /process\.env = {}/];
 
             var builtWithoutExceptions = exceptions.reduce(function(result, exception) {
                 return result.replace(exception, '');

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -36,26 +36,32 @@ describe('record creation', function() {
         airtable
             .base('app123')
             .table('Table')
-            .create({
-                foo: 'boo',
-                bar: 'yar',
-            }, function(err, createdRecord) {
-                expect(err).toBeNull();
-                expect(createdRecord.id).toBe('rec0');
-                expect(createdRecord.get('foo')).toBe('boo');
-                expect(createdRecord.get('bar')).toBe('yar');
-                done();
-            });
+            .create(
+                {
+                    foo: 'boo',
+                    bar: 'yar',
+                },
+                function(err, createdRecord) {
+                    expect(err).toBeNull();
+                    expect(createdRecord.id).toBe('rec0');
+                    expect(createdRecord.get('foo')).toBe('boo');
+                    expect(createdRecord.get('bar')).toBe('yar');
+                    done();
+                }
+            );
     });
 
     it('can add the "typecast" parameter when creating one record', function() {
         return airtable
             .base('app123')
             .table('Table')
-            .create({
-                foo: 'boo',
-                bar: 'yar',
-            }, {typecast: true})
+            .create(
+                {
+                    foo: 'boo',
+                    bar: 'yar',
+                },
+                {typecast: true}
+            )
             .then(function(createdRecord) {
                 expect(createdRecord.id).toBe('rec0');
                 expect(createdRecord.get('typecasted')).toBe(true);
@@ -66,9 +72,11 @@ describe('record creation', function() {
         return airtable
             .base('app123')
             .table('Table')
-            .create([{
-                fields: {foo: 'boo'}
-            }])
+            .create([
+                {
+                    fields: {foo: 'boo'},
+                },
+            ])
             .then(function(createdRecords) {
                 expect(createdRecords).toHaveLength(1);
                 expect(createdRecords[0].id).toBe('rec0');
@@ -80,10 +88,7 @@ describe('record creation', function() {
         return airtable
             .base('app123')
             .table('Table')
-            .create([
-                {fields: {foo: 'boo'}},
-                {fields: {bar: 'yar'}},
-            ])
+            .create([{fields: {foo: 'boo'}}, {fields: {bar: 'yar'}}])
             .then(function(createdRecords) {
                 expect(createdRecords).toHaveLength(2);
                 expect(createdRecords[0].id).toBe('rec0');
@@ -97,10 +102,10 @@ describe('record creation', function() {
         airtable
             .base('app123')
             .table('Table')
-            .create([
-                {fields: {foo: 'boo'}},
-                {fields: {bar: 'yar'}},
-            ], function(err, createdRecords) {
+            .create([{fields: {foo: 'boo'}}, {fields: {bar: 'yar'}}], function(
+                err,
+                createdRecords
+            ) {
                 expect(err).toBeNull();
                 expect(createdRecords).toHaveLength(2);
                 expect(createdRecords[0].id).toBe('rec0');
@@ -115,10 +120,7 @@ describe('record creation', function() {
         return airtable
             .base('app123')
             .table('Table')
-            .create([
-                {fields: {foo: 'boo'}},
-                {fields: {bar: 'yar'}},
-            ], {typecast: true})
+            .create([{fields: {foo: 'boo'}}, {fields: {bar: 'yar'}}], {typecast: true})
             .then(function(createdRecords) {
                 expect(createdRecords).toHaveLength(2);
                 expect(createdRecords[0].id).toBe('rec0');

--- a/test/object_to_query_param_string.test.js
+++ b/test/object_to_query_param_string.test.js
@@ -43,20 +43,25 @@ describe('objectToQueryParamString', function() {
 
     it('serializes arrays', function() {
         expect(objectToQueryParamString({arr: [1]})).toBe(encodeURIComponent('arr[]') + '=1');
-        expect(objectToQueryParamString({arr: [1, 2]})).toBe([
-            encodeURIComponent('arr[]'), '=', '1',
-            '&',
-            encodeURIComponent('arr[]'), '=', '2',
-        ].join(''));
+        expect(objectToQueryParamString({arr: [1, 2]})).toBe(
+            [
+                encodeURIComponent('arr[]'),
+                '=',
+                '1',
+                '&',
+                encodeURIComponent('arr[]'),
+                '=',
+                '2',
+            ].join('')
+        );
 
         expect(objectToQueryParamString({arr: []})).toBe('');
 
-        var actual = querystring.parse(objectToQueryParamString({
-            arr: [
-                {foo: 'boo'},
-                {foo: 'bar', baz: 'qux'},
-            ],
-        }));
+        var actual = querystring.parse(
+            objectToQueryParamString({
+                arr: [{foo: 'boo'}, {foo: 'bar', baz: 'qux'}],
+            })
+        );
         var expected = {
             'arr[0][foo]': 'boo',
             'arr[1][foo]': 'bar',
@@ -66,15 +71,19 @@ describe('objectToQueryParamString', function() {
     });
 
     it('serializes objects', function() {
-        expect(objectToQueryParamString({obj: {foo: 'boo'}})).toBe(encodeURIComponent('obj[foo]') + '=boo');
+        expect(objectToQueryParamString({obj: {foo: 'boo'}})).toBe(
+            encodeURIComponent('obj[foo]') + '=boo'
+        );
 
-        expect(objectToQueryParamString({
-            obj: {
-                foo: {
-                    bar: 'baz'
+        expect(
+            objectToQueryParamString({
+                obj: {
+                    foo: {
+                        bar: 'baz',
+                    },
                 },
-            }
-        })).toBe(encodeURIComponent('obj[foo][bar]') + '=baz');
+            })
+        ).toBe(encodeURIComponent('obj[foo][bar]') + '=baz');
 
         expect(objectToQueryParamString({obj: {}})).toBe('');
 
@@ -82,8 +91,10 @@ describe('objectToQueryParamString', function() {
             this.instanceProperty = prop;
         }
         Klass.prototype.prototypeProperty = 'should be ignored';
-        expect(objectToQueryParamString({
-            obj: new Klass('foo'),
-        })).toBe(encodeURIComponent('obj[instanceProperty]') + '=foo');
+        expect(
+            objectToQueryParamString({
+                obj: new Klass('foo'),
+            })
+        ).toBe(encodeURIComponent('obj[instanceProperty]') + '=foo');
     });
 });

--- a/test/record.test.js
+++ b/test/record.test.js
@@ -74,7 +74,13 @@ describe('Record', function() {
                 fields: {foo: 'bar'},
             });
 
-            table._base.runAction.mockImplementationOnce(function(method, path, queryParams, bodyData, callback) {
+            table._base.runAction.mockImplementationOnce(function(
+                method,
+                path,
+                queryParams,
+                bodyData,
+                callback
+            ) {
                 callback(null, null, {
                     id: bodyData.id,
                     createdTime: '2020-04-20T16:20:00.000Z',
@@ -91,21 +97,26 @@ describe('Record', function() {
                 expect(record.get('foo')).toEqual('bar');
                 expect(record.get('baz')).toEqual('qux');
 
-                expect(table._base.runAction).toHaveBeenCalledWith('patch', '/My%20Table/rec123', {}, {
-                    fields: {baz: 'qux'}
-                }, expect.any(Function));
+                expect(table._base.runAction).toHaveBeenCalledWith(
+                    'patch',
+                    '/My%20Table/rec123',
+                    {},
+                    {
+                        fields: {baz: 'qux'},
+                    },
+                    expect.any(Function)
+                );
 
                 done();
             });
         });
 
         it('returns a promise when no callback is passed', function() {
-            return record.patchUpdate({baz: 'qux'})
-                .then(function(updatedRecord) {
-                    expect(updatedRecord).toBe(record);
-                    expect(record.get('foo')).toEqual('bar');
-                    expect(record.get('baz')).toEqual('qux');
-                });
+            return record.patchUpdate({baz: 'qux'}).then(function(updatedRecord) {
+                expect(updatedRecord).toBe(record);
+                expect(record.get('foo')).toEqual('bar');
+                expect(record.get('baz')).toEqual('qux');
+            });
         });
 
         it('aliases "updateFields"', function() {
@@ -122,7 +133,13 @@ describe('Record', function() {
                 fields: {foo: 'bar'},
             });
 
-            table._base.runAction.mockImplementationOnce(function(method, path, queryParams, bodyData, callback) {
+            table._base.runAction.mockImplementationOnce(function(
+                method,
+                path,
+                queryParams,
+                bodyData,
+                callback
+            ) {
                 callback(null, null, {
                     id: bodyData.id,
                     createdTime: '2020-04-20T16:20:00.000Z',
@@ -139,21 +156,26 @@ describe('Record', function() {
                 expect(record.get('foo')).toBeUndefined();
                 expect(record.get('baz')).toEqual('qux');
 
-                expect(table._base.runAction).toHaveBeenCalledWith('put', '/My%20Table/rec123', {}, {
-                    fields: {baz: 'qux'}
-                }, expect.any(Function));
+                expect(table._base.runAction).toHaveBeenCalledWith(
+                    'put',
+                    '/My%20Table/rec123',
+                    {},
+                    {
+                        fields: {baz: 'qux'},
+                    },
+                    expect.any(Function)
+                );
 
                 done();
             });
         });
 
         it('returns a promise when no callback is passed', function() {
-            return record.patchUpdate({baz: 'qux'})
-                .then(function(updatedRecord) {
-                    expect(updatedRecord).toBe(record);
-                    expect(record.get('foo')).toBeUndefined();
-                    expect(record.get('baz')).toEqual('qux');
-                });
+            return record.patchUpdate({baz: 'qux'}).then(function(updatedRecord) {
+                expect(updatedRecord).toBe(record);
+                expect(record.get('foo')).toBeUndefined();
+                expect(record.get('baz')).toEqual('qux');
+            });
         });
 
         it('aliases "replaceFields"', function() {
@@ -163,7 +185,13 @@ describe('Record', function() {
 
     describe('fetch', function() {
         beforeEach(function() {
-            table._base.runAction.mockImplementationOnce(function(method, path, queryParams, bodyData, callback) {
+            table._base.runAction.mockImplementationOnce(function(
+                method,
+                path,
+                queryParams,
+                bodyData,
+                callback
+            ) {
                 callback(null, null, {
                     id: 'rec123',
                     createdTime: '2020-04-20T16:20:00.000Z',
@@ -182,7 +210,13 @@ describe('Record', function() {
                 expect(record.get('foo')).toBe('bar');
                 expect(record.get('baz')).toBeUndefined();
 
-                expect(table._base.runAction).toHaveBeenCalledWith('get', '/My%20Table/rec123', {}, null, expect.any(Function));
+                expect(table._base.runAction).toHaveBeenCalledWith(
+                    'get',
+                    '/My%20Table/rec123',
+                    {},
+                    null,
+                    expect.any(Function)
+                );
 
                 done();
             });

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -51,7 +51,7 @@ function getMockEnvironmentAsync() {
                     return {
                         id: record.id,
                         createdTime: FAKE_CREATED_TIME,
-                        fields: fields
+                        fields: fields,
                     };
                 }),
             });
@@ -67,7 +67,7 @@ function getMockEnvironmentAsync() {
     app.delete('/v0/:baseId/:tableIdOrName/:recordId', _checkParamsMiddleware, function(req, res) {
         res.json({
             id: req.params.recordId,
-            deleted: true
+            deleted: true,
         });
     });
 
@@ -76,20 +76,21 @@ function getMockEnvironmentAsync() {
             records: req.query.records.map(function(recordId) {
                 return {
                     id: recordId,
-                    deleted: true
+                    deleted: true,
                 };
-            })
+            }),
         });
     });
 
-    app.use(function(err, req, res, next) { // eslint-disable-line no-unused-vars
+    // eslint-disable-next-line no-unused-vars
+    app.use(function(err, req, res, next) {
         console.error(err);
         res.status(500);
         res.json({
             error: {
                 type: 'TEST_ERROR',
                 message: err.message,
-            }
+            },
         });
     });
 
@@ -113,11 +114,10 @@ function getMockEnvironmentAsync() {
 }
 
 function _checkParamsMiddleware(req, res, next) {
-    var areParamsValid = (
-        (req.get('authorization') === 'Bearer key123') &&
-    (req.params.baseId === 'app123') &&
-    (req.params.tableIdOrName === 'Table')
-    );
+    var areParamsValid =
+        req.get('authorization') === 'Bearer key123' &&
+        req.params.baseId === 'app123' &&
+        req.params.tableIdOrName === 'Table';
     if (areParamsValid) {
         next();
     } else {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -37,26 +37,34 @@ describe('record updates', function() {
             airtable
                 .base('app123')
                 .table('Table')
-                .update('rec123', {
-                    foo: 'boo',
-                    bar: 'yar',
-                }, function(err, updatedRecord) {
-                    expect(err).toBeNull();
-                    expect(updatedRecord.id).toBe('rec123');
-                    expect(updatedRecord.get('foo')).toBe('boo');
-                    expect(updatedRecord.get('bar')).toBe('yar');
-                    done();
-                });
+                .update(
+                    'rec123',
+                    {
+                        foo: 'boo',
+                        bar: 'yar',
+                    },
+                    function(err, updatedRecord) {
+                        expect(err).toBeNull();
+                        expect(updatedRecord.id).toBe('rec123');
+                        expect(updatedRecord.get('foo')).toBe('boo');
+                        expect(updatedRecord.get('bar')).toBe('yar');
+                        done();
+                    }
+                );
         });
 
         it('can add the "typecast" parameter when updating one record', function() {
             return airtable
                 .base('app123')
                 .table('Table')
-                .update('rec123', {
-                    foo: 'boo',
-                    bar: 'yar',
-                }, {typecast: true})
+                .update(
+                    'rec123',
+                    {
+                        foo: 'boo',
+                        bar: 'yar',
+                    },
+                    {typecast: true}
+                )
                 .then(function(updatedRecord) {
                     expect(updatedRecord.id).toBe('rec123');
                     expect(updatedRecord.get('typecasted')).toBe(true);
@@ -67,10 +75,12 @@ describe('record updates', function() {
             return airtable
                 .base('app123')
                 .table('Table')
-                .update([{
-                    id: 'rec123',
-                    fields: {foo: 'boo'},
-                }])
+                .update([
+                    {
+                        id: 'rec123',
+                        fields: {foo: 'boo'},
+                    },
+                ])
                 .then(function(updatedRecords) {
                     expect(updatedRecords).toHaveLength(1);
                     expect(updatedRecords[0].id).toBe('rec123');
@@ -105,40 +115,46 @@ describe('record updates', function() {
             airtable
                 .base('app123')
                 .table('Table')
-                .update([
-                    {
-                        id: 'rec123',
-                        fields: {foo: 'boo'},
-                    },
-                    {
-                        id: 'rec456',
-                        fields: {bar: 'yar'},
-                    },
-                ], function(err, updatedRecords) {
-                    expect(err).toBeNull();
-                    expect(updatedRecords).toHaveLength(2);
-                    expect(updatedRecords[0].id).toBe('rec123');
-                    expect(updatedRecords[0].get('foo')).toBe('boo');
-                    expect(updatedRecords[1].id).toBe('rec456');
-                    expect(updatedRecords[1].get('bar')).toBe('yar');
-                    done();
-                });
+                .update(
+                    [
+                        {
+                            id: 'rec123',
+                            fields: {foo: 'boo'},
+                        },
+                        {
+                            id: 'rec456',
+                            fields: {bar: 'yar'},
+                        },
+                    ],
+                    function(err, updatedRecords) {
+                        expect(err).toBeNull();
+                        expect(updatedRecords).toHaveLength(2);
+                        expect(updatedRecords[0].id).toBe('rec123');
+                        expect(updatedRecords[0].get('foo')).toBe('boo');
+                        expect(updatedRecords[1].id).toBe('rec456');
+                        expect(updatedRecords[1].get('bar')).toBe('yar');
+                        done();
+                    }
+                );
         });
 
         it('can update two records with the "typecast" parameter', function() {
             return airtable
                 .base('app123')
                 .table('Table')
-                .update([
-                    {
-                        id: 'rec123',
-                        fields: {foo: 'boo'},
-                    },
-                    {
-                        id: 'rec456',
-                        fields: {bar: 'yar'},
-                    },
-                ], {typecast: true})
+                .update(
+                    [
+                        {
+                            id: 'rec123',
+                            fields: {foo: 'boo'},
+                        },
+                        {
+                            id: 'rec456',
+                            fields: {bar: 'yar'},
+                        },
+                    ],
+                    {typecast: true}
+                )
                 .then(function(updatedRecords) {
                     expect(updatedRecords).toHaveLength(2);
                     expect(updatedRecords[0].id).toBe('rec123');
@@ -169,10 +185,14 @@ describe('record updates', function() {
             return airtable
                 .base('app123')
                 .table('Table')
-                .replace('rec123', {
-                    foo: 'boo',
-                    bar: 'yar',
-                }, {typecast: true})
+                .replace(
+                    'rec123',
+                    {
+                        foo: 'boo',
+                        bar: 'yar',
+                    },
+                    {typecast: true}
+                )
                 .then(function(updatedRecord) {
                     expect(updatedRecord.id).toBe('rec123');
                     expect(updatedRecord.get('typecasted')).toBe(true);
@@ -183,10 +203,12 @@ describe('record updates', function() {
             return airtable
                 .base('app123')
                 .table('Table')
-                .replace([{
-                    id: 'rec123',
-                    fields: {foo: 'boo'},
-                }])
+                .replace([
+                    {
+                        id: 'rec123',
+                        fields: {foo: 'boo'},
+                    },
+                ])
                 .then(function(updatedRecords) {
                     expect(updatedRecords).toHaveLength(1);
                     expect(updatedRecords[0].id).toBe('rec123');
@@ -221,16 +243,19 @@ describe('record updates', function() {
             return airtable
                 .base('app123')
                 .table('Table')
-                .replace([
-                    {
-                        id: 'rec123',
-                        fields: {foo: 'boo'},
-                    },
-                    {
-                        id: 'rec456',
-                        fields: {bar: 'yar'},
-                    },
-                ], {typecast: true})
+                .replace(
+                    [
+                        {
+                            id: 'rec123',
+                            fields: {foo: 'boo'},
+                        },
+                        {
+                            id: 'rec456',
+                            fields: {bar: 'yar'},
+                        },
+                    ],
+                    {typecast: true}
+                )
                 .then(function(updatedRecords) {
                     expect(updatedRecords).toHaveLength(2);
                     expect(updatedRecords[0].id).toBe('rec123');


### PR DESCRIPTION
This adds a new npm script, `npm run format`, which runs Prettier on all JavaScript files in the repo (except for built files).

The bulk of this change was actually running Prettier. Only three files are particularly relevant to review:

- `.prettierignore`
- `.prettierrc.json`
- `package.json`

In the future, I plan to add pre-commit hooks with [Husky][1] and auto-formatting of other file types, like JSON and Markdown.

[1]: https://www.npmjs.com/package/husky