### PR TITLE
Remove `allowUnauthorizedSsl` option

### DIFF
--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -25,12 +25,6 @@ function Airtable(opts) {
         _apiVersionMajor: {
             value: apiVersion.split('.')[0],
         },
-        _allowUnauthorizedSsl: {
-            value:
-                opts.allowUnauthorizedSsl ||
-                Airtable.allowUnauthorizedSsl ||
-                defaultConfig.allowUnauthorizedSsl,
-        },
         _noRetryIfRateLimited: {
             value:
                 opts.noRetryIfRateLimited ||
@@ -55,7 +49,6 @@ Airtable.default_config = function() {
         endpointUrl: process.env.AIRTABLE_ENDPOINT_URL || 'https://api.airtable.com',
         apiVersion: '0.1.0',
         apiKey: process.env.AIRTABLE_API_KEY,
-        allowUnauthorizedSsl: false,
         noRetryIfRateLimited: false,
         requestTimeout: 300 * 1000, // 5 minutes
     };
@@ -65,7 +58,6 @@ Airtable.configure = function(opts) {
     Airtable.apiKey = opts.apiKey;
     Airtable.endpointUrl = opts.endpointUrl;
     Airtable.apiVersion = opts.apiVersion;
-    Airtable.allowUnauthorizedSsl = opts.allowUnauthorizedSsl;
     Airtable.noRetryIfRateLimited = opts.noRetryIfRateLimited;
 };
 

--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -40,10 +40,6 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         json: true,
         timeout: base._airtable.requestTimeout,
         headers: headers,
-        // agentOptions are ignored when running in the browser.
-        agentOptions: {
-            rejectUnauthorized: !base._airtable._allowUnauthorizedSsl,
-        },
     };
 
     if (bodyData !== null) {


### PR DESCRIPTION
This removes the undocumented `allowUnauthorizedSsl` option, as it limits the security of the library.

I would argue that this is a breaking change, and probably merits a minor version bump.

As an alterative, we could mark this option as deprecated and remove it in `airtable@1.0.0`.