### PR TITLE
Add `Base#makeRequest`, an improved version of `Base#runAction`

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -1,10 +1,22 @@
 'use strict';
 
 var forEach = require('lodash/forEach');
+var get = require('lodash/get');
+var assign = require('lodash/assign');
+var isPlainObject = require('lodash/isPlainObject');
+
+// This will become require('xhr') in the browser.
+var request = require('request');
 
 var AirtableError = require('./airtable_error');
 var Table = require('./table');
+var HttpHeaders = require('./http_headers');
 var runAction = require('./run_action');
+var packageVersion = require('./package_version');
+var exponentialBackoffWithJitter = require('./exponential_backoff_with_jitter');
+var Promise = require('./promise');
+
+var userAgent = 'Airtable.js/' + packageVersion;
 
 function Base(airtable, baseId) {
     this._airtable = airtable;
@@ -15,8 +27,80 @@ Base.prototype.table = function(tableName) {
     return new Table(this, null, tableName);
 };
 
+Base.prototype.makeRequest = function(options) {
+    var that = this;
+
+    options = options || {};
+
+    var method = get(options, 'method', 'GET').toUpperCase();
+
+    var requestOptions = {
+        method: method,
+        url:
+            this._airtable._endpointUrl +
+            '/v' +
+            this._airtable._apiVersionMajor +
+            '/' +
+            this._id +
+            get(options, 'path', '/'),
+        qs: get(options, 'qs', {}),
+        headers: this._getRequestHeaders(get(options, 'headers', {})),
+        json: true,
+        timeout: this._airtable.requestTimeout,
+    };
+    if ('body' in options && _canRequestMethodIncludeBody(method)) {
+        requestOptions.body = options.body;
+    }
+
+    return new Promise(function(resolve, reject) {
+        request(requestOptions, function(err, response, body) {
+            if (!err && response.statusCode === 429 && !that._airtable._noRetryIfRateLimited) {
+                var numAttempts = get(options, '_numAttempts', 0);
+                var backoffDelayMs = exponentialBackoffWithJitter(numAttempts);
+                setTimeout(function() {
+                    var newOptions = assign({}, options, {
+                        _numAttempts: numAttempts + 1,
+                    });
+                    that.makeRequest(newOptions)
+                        .then(resolve)
+                        .catch(reject);
+                }, backoffDelayMs);
+                return;
+            }
+
+            err =
+                err ||
+                that._checkStatusForError(response.statusCode, body) ||
+                _getErrorForNonObjectBody(response.statusCode, body);
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve({
+                statusCode: response.statusCode,
+                headers: response.headers,
+                body: body,
+            });
+        });
+    });
+};
+
+// This method is deprecated.
 Base.prototype.runAction = function(method, path, queryParams, bodyData, callback) {
     runAction(this, method, path, queryParams, bodyData, callback, 0);
+};
+
+Base.prototype._getRequestHeaders = function(headers) {
+    var result = new HttpHeaders();
+
+    result.set('Authorization', 'Bearer ' + this._airtable._apiKey);
+    result.set('User-Agent', userAgent);
+    forEach(headers, function(headerValue, headerKey) {
+        result.set(headerKey, headerValue);
+    });
+
+    return result.toJSON();
 };
 
 Base.prototype._checkStatusForError = function(statusCode, body) {
@@ -97,12 +181,28 @@ Base.createFunctor = function(airtable, baseId) {
     var baseFn = function() {
         return base.doCall.apply(base, arguments);
     };
-    forEach(['table', 'runAction', 'getId'], function(baseMethod) {
+    forEach(['table', 'makeRequest', 'runAction', 'getId'], function(baseMethod) {
         baseFn[baseMethod] = base[baseMethod].bind(base);
     });
     baseFn._base = base;
     baseFn.tables = base.tables;
     return baseFn;
 };
+
+function _canRequestMethodIncludeBody(method) {
+    return method !== 'GET' && method !== 'DELETE';
+}
+
+function _getErrorForNonObjectBody(statusCode, body) {
+    if (isPlainObject(body)) {
+        return null;
+    } else {
+        return new AirtableError(
+            'UNEXPECTED_ERROR',
+            'The response from Airtable was invalid JSON. Please try again soon.',
+            statusCode
+        );
+    }
+}
 
 module.exports = Base;

--- a/lib/exponential_backoff_with_jitter.js
+++ b/lib/exponential_backoff_with_jitter.js
@@ -1,0 +1,15 @@
+var internalConfig = require('./internal_config.json');
+
+// "Full Jitter" algorithm taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+function exponentialBackoffWithJitter(numberOfRetries) {
+    var rawBackoffTimeMs =
+        internalConfig.INITIAL_RETRY_DELAY_IF_RATE_LIMITED * Math.pow(2, numberOfRetries);
+    var clippedBackoffTimeMs = Math.min(
+        internalConfig.MAX_RETRY_DELAY_IF_RATE_LIMITED,
+        rawBackoffTimeMs
+    );
+    var jitteredBackoffTimeMs = Math.random() * clippedBackoffTimeMs;
+    return jitteredBackoffTimeMs;
+}
+
+module.exports = exponentialBackoffWithJitter;

--- a/lib/http_headers.js
+++ b/lib/http_headers.js
@@ -1,0 +1,40 @@
+var forEach = require('lodash/forEach');
+
+var isBrowser = typeof window !== 'undefined';
+
+function HttpHeaders() {
+    this._headersByLowercasedKey = {};
+}
+
+HttpHeaders.prototype.set = function(headerKey, headerValue) {
+    var lowercasedKey = headerKey.toLowerCase();
+
+    if (lowercasedKey === 'x-airtable-user-agent') {
+        lowercasedKey = 'user-agent';
+        headerKey = 'User-Agent';
+    }
+
+    this._headersByLowercasedKey[lowercasedKey] = {
+        headerKey: headerKey,
+        headerValue: headerValue,
+    };
+};
+
+HttpHeaders.prototype.toJSON = function() {
+    var result = {};
+    forEach(this._headersByLowercasedKey, function(headerDefinition, lowercasedKey) {
+        var headerKey;
+        if (isBrowser && lowercasedKey === 'user-agent') {
+            // Some browsers do not allow overriding the user agent.
+            // https://github.com/Airtable/airtable.js/issues/52
+            headerKey = 'X-Airtable-User-Agent';
+        } else {
+            headerKey = headerDefinition.headerKey;
+        }
+
+        result[headerKey] = headerDefinition.headerValue;
+    });
+    return result;
+};
+
+module.exports = HttpHeaders;

--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var internalConfig = require('./internal_config.json');
+var exponentialBackoffWithJitter = require('./exponential_backoff_with_jitter');
 var objectToQueryParamString = require('./object_to_query_param_string');
 var packageVersion = require('./package_version');
 
@@ -8,14 +8,6 @@ var packageVersion = require('./package_version');
 var request = require('request');
 
 var userAgent = 'Airtable.js/' + packageVersion;
-
-// "Full Jitter" algorithm taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-function exponentialBackoffWithJitter(numberOfRetries, initialBackoffTimeMs, maxBackoffTimeMs) {
-    var rawBackoffTimeMs = initialBackoffTimeMs * Math.pow(2, numberOfRetries);
-    var clippedBackoffTimeMs = Math.min(maxBackoffTimeMs, rawBackoffTimeMs);
-    var jitteredBackoffTimeMs = Math.random() * clippedBackoffTimeMs;
-    return jitteredBackoffTimeMs;
-}
 
 function runAction(base, method, path, queryParams, bodyData, callback, numAttempts) {
     var url =
@@ -65,11 +57,7 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         }
 
         if (resp.statusCode === 429 && !base._airtable._noRetryIfRateLimited) {
-            var backoffDelayMs = exponentialBackoffWithJitter(
-                numAttempts,
-                internalConfig.INITIAL_RETRY_DELAY_IF_RATE_LIMITED,
-                internalConfig.MAX_RETRY_DELAY_IF_RATE_LIMITED
-            );
+            var backoffDelayMs = exponentialBackoffWithJitter(numAttempts);
             setTimeout(function() {
                 runAction(base, method, path, queryParams, bodyData, callback, numAttempts + 1);
             }, backoffDelayMs);

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,43 +1,484 @@
 'use strict';
 
-var request = require('request');
-var version = require('../package.json').version;
 var Airtable = require('../lib/airtable');
-
-jest.mock('request');
+var version = require('../package.json').version;
+var testHelpers = require('./test_helpers');
 
 describe('Base', function() {
-    describe('#runAction', function() {
-        it('makes requests with the right options', function() {
-            var fakeAirtable = new Airtable({
-                apiKey: 'keyXyz',
-                requestTimeout: 1234,
+    var airtable;
+    var teardownAsync;
+    var testExpressApp;
+    var fakeBase;
+
+    beforeEach(function() {
+        return testHelpers.getMockEnvironmentAsync().then(function(env) {
+            airtable = env.airtable;
+            teardownAsync = env.teardownAsync;
+            testExpressApp = env.testExpressApp;
+            fakeBase = airtable.base('app123');
+        });
+    });
+
+    afterEach(function() {
+        return teardownAsync();
+    });
+
+    describe('#makeRequest', function() {
+        beforeEach(function() {
+            testExpressApp.set('handler override', function(req, res) {
+                res.json({foo: 'bar'});
             });
-            var fakeBase = fakeAirtable.base('app123');
+        });
 
-            fakeBase.runAction('get', '/my_table/rec456', {}, null, function() {});
+        describe('HTTP method', function() {
+            it('makes a GET request by default', function() {
+                return fakeBase.makeRequest().then(function() {
+                    expect(testExpressApp.get('most recent request').method).toEqual('GET');
+                });
+            });
 
-            expect(request).toHaveBeenCalledTimes(1);
-            expect(request).toHaveBeenCalledWith(
-                {
-                    method: 'GET',
-                    url: 'https://api.airtable.com/v0/app123/my_table/rec456?',
-                    json: true,
-                    timeout: 1234,
-                    headers: {
-                        authorization: 'Bearer keyXyz',
-                        'x-api-version': '0.1.0',
-                        'x-airtable-application-id': 'app123',
-                        'User-Agent': 'Airtable.js/' + version,
-                    },
-                    agentOptions: {
-                        rejectUnauthorized: true,
-                    },
-                },
-                expect.any(Function)
-            );
+            ['get', 'post', 'patch', 'put', 'delete'].forEach(function(method) {
+                it('can set the HTTP method to ' + method, function() {
+                    return fakeBase.makeRequest({method: method}).then(function() {
+                        expect(testExpressApp.get('most recent request').method).toEqual(
+                            method.toUpperCase()
+                        );
+                    });
+                });
+            });
+        });
 
+        describe('path', function() {
+            it('makes a request to the base root URL by default', function() {
+                return fakeBase.makeRequest().then(function() {
+                    expect(testExpressApp.get('most recent request').path).toEqual('/v0/app123/');
+                });
+            });
+
+            it('can make requests to other paths', function() {
+                return fakeBase.makeRequest({path: '/foo/bar'}).then(function() {
+                    expect(testExpressApp.get('most recent request').path).toEqual(
+                        '/v0/app123/foo/bar'
+                    );
+                });
+            });
+        });
+
+        describe('query strings', function() {
+            it("doesn't set a query string by default", function() {
+                return fakeBase.makeRequest().then(function() {
+                    expect([...testExpressApp.get('most recent request').query.entries()]).toEqual(
+                        []
+                    );
+                });
+            });
+
+            it('can set the query string', function() {
+                return fakeBase
+                    .makeRequest({
+                        qs: {
+                            foo: 'bar',
+                            arr: ['one', 'two'],
+                            obj: {baz: 'qux'},
+                        },
+                    })
+                    .then(function() {
+                        const {query} = testExpressApp.get('most recent request');
+                        expect(query.getAll('foo')).toEqual(['bar']);
+                        expect(query.getAll('arr[0]')).toEqual(['one']);
+                        expect(query.getAll('arr[1]')).toEqual(['two']);
+                        expect(query.getAll('obj[baz]')).toEqual(['qux']);
+                    });
+            });
+        });
+
+        describe('headers', function() {
+            it('sets two headers by default', function() {
+                return fakeBase.makeRequest().then(function() {
+                    const req = testExpressApp.get('most recent request');
+                    expect(req.get('authorization')).toEqual('Bearer key123');
+                    expect(req.get('user-agent')).toEqual('Airtable.js/' + version);
+                });
+            });
+
+            it('can set additional headers', function() {
+                return fakeBase
+                    .makeRequest({
+                        headers: {
+                            'X-Foo': 'bar',
+                            'X-Bar': 'baz',
+                        },
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.get('authorization')).toEqual('Bearer key123');
+                        expect(req.get('user-agent')).toEqual('Airtable.js/' + version);
+                        expect(req.get('x-foo')).toEqual('bar');
+                        expect(req.get('x-bar')).toEqual('baz');
+                    });
+            });
+
+            it('can override default headers if specified with the right casing', function() {
+                return fakeBase
+                    .makeRequest({
+                        headers: {
+                            Authorization: 'foo',
+                            'User-Agent': 'bar',
+                        },
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.get('authorization')).toEqual('foo');
+                        expect(req.get('user-agent')).toEqual('bar');
+                    });
+            });
+
+            it('can override default headers if specified with different casing', function() {
+                return fakeBase
+                    .makeRequest({
+                        headers: {
+                            authorization: 'foo',
+                            'uSER-aGENT': 'bar',
+                        },
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.get('authorization')).toEqual('foo');
+                        expect(req.get('user-agent')).toEqual('bar');
+                    });
+            });
+
+            it('allows multiple headers with different casings; one will "win"', function() {
+                return fakeBase
+                    .makeRequest({
+                        headers: {
+                            'x-foo': 'bar',
+                            'X-Foo': 'baz',
+                        },
+                    })
+                    .then(function() {
+                        const value = testExpressApp.get('most recent request').get('x-foo');
+                        expect(value === 'bar' || value === 'baz').toBeTruthy();
+                    });
+            });
+        });
+
+        describe('request body', function() {
+            it('can include a body', function() {
+                return fakeBase
+                    .makeRequest({
+                        method: 'post',
+                        body: {foo: 'bar'},
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.is('json')).toBeTruthy();
+                        expect(req.body).toEqual({foo: 'bar'});
+                    });
+            });
+
+            it('ignores the body for GET requests', function() {
+                return fakeBase
+                    .makeRequest({
+                        method: 'get',
+                        body: {foo: 'bar'},
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.body).toEqual({});
+                    });
+            });
+
+            it('ignores the body for DELETE requests', function() {
+                return fakeBase
+                    .makeRequest({
+                        method: 'delete',
+                        body: {foo: 'bar'},
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.body).toEqual({});
+                    });
+            });
+        });
+
+        describe('error handling', function() {
+            it('handles 401s', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(401).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'AUTHENTICATION_REQUIRED',
+                    message: expect.any(String),
+                    statusCode: 401,
+                });
+            });
+
+            it('handles 403s', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(403).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'NOT_AUTHORIZED',
+                    message: expect.any(String),
+                    statusCode: 403,
+                });
+            });
+
+            it('handles 404s without an error message', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(404).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'NOT_FOUND',
+                    message: expect.any(String),
+                    statusCode: 404,
+                });
+            });
+
+            it('handles 404s with an error message', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(404).json({
+                        error: {
+                            message: 'foo bar',
+                        },
+                    });
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'NOT_FOUND',
+                    message: 'foo bar',
+                    statusCode: 404,
+                });
+            });
+
+            it('handles 413s', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(413).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'REQUEST_TOO_LARGE',
+                    message: expect.any(String),
+                    statusCode: 413,
+                });
+            });
+
+            it('handles 422s without a type or message', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(422).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'UNPROCESSABLE_ENTITY',
+                    message: expect.any(String),
+                    statusCode: 422,
+                });
+            });
+
+            it("handles 422s and respects the server's error type", function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(422).json({
+                        error: {
+                            type: 'FOO_BAR',
+                        },
+                    });
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'FOO_BAR',
+                    message: expect.any(String),
+                    statusCode: 422,
+                });
+            });
+
+            it("handles 422s and respects the server's error message", function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(422).json({
+                        error: {
+                            message: 'foo bar',
+                        },
+                    });
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'UNPROCESSABLE_ENTITY',
+                    message: 'foo bar',
+                    statusCode: 422,
+                });
+            });
+
+            it('handles 429s immediately when retries are turned off', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(429).end();
+                });
+
+                var base = new Airtable({
+                    apiKey: 'key123',
+                    endpointUrl: airtable._endpointUrl,
+                    noRetryIfRateLimited: true,
+                }).base('app123');
+
+                return expect(base.makeRequest()).rejects.toEqual({
+                    error: 'TOO_MANY_REQUESTS',
+                    message: expect.any(String),
+                    statusCode: 429,
+                });
+            });
+
+            it('retries 429s until success', function() {
+                const realSetTimeout = setTimeout;
+
+                jest.useFakeTimers();
+
+                let numberOfRequests = 0;
+                testExpressApp.set('handler override', (req, res) => {
+                    numberOfRequests++;
+                    if (numberOfRequests < 3) {
+                        res.status(429).end();
+                        realSetTimeout(() => {
+                            jest.runAllTimers();
+                        }, 10);
+                    } else {
+                        res.json({foo: 'bar'});
+                    }
+                });
+
+                return fakeBase.makeRequest().then(function() {
+                    expect(numberOfRequests).toEqual(3);
+                    jest.useRealTimers();
+                });
+            });
+
+            it('handles 500s', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(500).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'SERVER_ERROR',
+                    message: expect.any(String),
+                    statusCode: 500,
+                });
+            });
+
+            it('handles 503s', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(503).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'SERVICE_UNAVAILABLE',
+                    message: expect.any(String),
+                    statusCode: 503,
+                });
+            });
+
+            it('handles other 4xx errors without a type or message', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(402).end();
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'UNEXPECTED_ERROR',
+                    message: expect.any(String),
+                    statusCode: 402,
+                });
+            });
+
+            it("handles other 4xx errors, respecting the server's type", function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(402).json({
+                        error: {type: 'FOO_BAR'},
+                    });
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'FOO_BAR',
+                    message: expect.any(String),
+                    statusCode: 402,
+                });
+            });
+
+            it("handles other 4xx errors, respecting the server's message", function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.status(402).json({
+                        error: {message: 'foo bar'},
+                    });
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'UNEXPECTED_ERROR',
+                    message: 'foo bar',
+                    statusCode: 402,
+                });
+            });
+
+            it('errors with non-JSON response bodies (even if the Content-Type header is correct)', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.set('Content-Type', 'application/json');
+                    res.send('{"foo":');
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'UNEXPECTED_ERROR',
+                    message: expect.any(String),
+                    statusCode: 200,
+                });
+            });
+
+            it('errors with non-object response bodies', function() {
+                testExpressApp.set('handler override', (req, res) => {
+                    res.json(['foo', 'bar']);
+                });
+
+                return expect(fakeBase.makeRequest()).rejects.toEqual({
+                    error: 'UNEXPECTED_ERROR',
+                    message: expect.any(String),
+                    statusCode: 200,
+                });
+            });
+        });
+
+        describe('result', function() {
+            it('includes the status code in the result', function() {
+                return expect(fakeBase.makeRequest()).resolves.toMatchObject({
+                    statusCode: 200,
+                });
+            });
+
+            it('includes the headers the result', function() {
+                return expect(fakeBase.makeRequest()).resolves.toMatchObject({
+                    headers: {},
+                });
+            });
+
+            it('includes the body the result', function() {
+                return expect(fakeBase.makeRequest()).resolves.toMatchObject({
+                    body: {foo: 'bar'},
+                });
+            });
+        });
+    });
+
+    describe('#runAction (deprecated)', function() {
+        it('makes requests with the right options', function(done) {
             expect(version).toEqual(expect.stringMatching(/^\d+\.\d+\.\d+$/));
+
+            fakeBase.runAction('get', '/my_table/rec456', {}, null, function() {
+                const req = testExpressApp.get('most recent request');
+                expect(req.method).toEqual('GET');
+                expect(req.path).toEqual('/v0/app123/my_table/rec456');
+                expect(req.get('authorization')).toEqual('Bearer key123');
+                expect(req.get('x-api-version')).toEqual('0.1.0');
+                expect(req.get('x-airtable-application-id')).toEqual('app123');
+                expect(req.get('user-agent')).toEqual('Airtable.js/' + version);
+
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
`Base.prototype.runAction` has four problems:

1. You can't set custom HTTP headers in your outgoing request. (This is the main motivation for this change.)
2. Because all of the arguments are positional, it's not as easily extended.
3. Its test coverage is minimal.
4. Its interface doesn't match other common HTTP libraries, like `request` or `axios`.

This introduces a new method, `Base.prototype.makeRequest`, which aims to alleviate these concerns.