### PR TITLE
Update README.md - reference JS tab in api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can also override the settings per connection:
 
 # Interactive documentation
 
-Go to https://airtable.com/api to see the interactive API documentation for your Airtable bases. Once you select a base to view the API, make sure to click the the tab "Javascript" in the sandbox enviroment.  It'll have examples for all operations you can perform against your bases using this library.
+Go to https://airtable.com/api to see the interactive API documentation for your Airtable bases. Once you select a base, click the "JavaScript" tab to see code snippets using Airtable.js. It'll have examples for all operations you can perform against your base using this library.
 
 # Promises
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can also override the settings per connection:
 
 # Interactive documentation
 
-Go to https://airtable.com/api to see the interactive API documentation for your Airtable bases. It'll have examples for all operations you can perform against your bases.
+Go to https://airtable.com/api to see the interactive API documentation for your Airtable bases. Once you select a base to view the API, make sure to click the the tab "Javascript" in the sandbox enviroment.  It'll have examples for all operations you can perform against your bases using this library.
 
 # Promises
 


### PR DESCRIPTION
Adding a reference to the existence of a Javascript tab in the Airtable API documentation. 

I was struggling to find documentation for this library and https://github.com/Airtable/airtable.js/issues/93 made me realize I was just not noticing the JS tab. Since it seems to be occurring to multiple people on the thread, adding it explicitly in the readme might help save someone some hours of research.