### PR TITLE
Adding debug mode to request module at base.js

### DIFF
--- a/lib/airtable.js
+++ b/lib/airtable.js
@@ -40,8 +40,11 @@ function Airtable(opts) {
     }
 }
 
-Airtable.prototype.base = function(baseId) {
-    return Base.createFunctor(this, baseId);
+Airtable.prototype.base = function(baseId, debug) {
+    if (typeof debug !== 'boolean') {
+        debug = false;
+    }
+    return Base.createFunctor(this, baseId, debug);
 };
 
 Airtable.default_config = function() {
@@ -61,8 +64,11 @@ Airtable.configure = function(opts) {
     Airtable.noRetryIfRateLimited = opts.noRetryIfRateLimited;
 };
 
-Airtable.base = function(baseId) {
-    return new Airtable().base(baseId);
+Airtable.base = function(baseId, debug) {
+    if (typeof debug !== 'boolean') {
+        debug = false;
+    }
+    return new Airtable().base(baseId, debug);
 };
 
 Airtable.Base = Base;

--- a/lib/base.js
+++ b/lib/base.js
@@ -18,9 +18,13 @@ var Promise = require('./promise');
 
 var userAgent = 'Airtable.js/' + packageVersion;
 
-function Base(airtable, baseId) {
+function Base(airtable, baseId, debug) {
+    if (typeof debug !== 'boolean') {
+        debug = false;
+    }
     this._airtable = airtable;
     this._id = baseId;
+    request.debug = debug;
 }
 
 Base.prototype.table = function(tableName) {
@@ -180,8 +184,11 @@ Base.prototype.getId = function() {
     return this._id;
 };
 
-Base.createFunctor = function(airtable, baseId) {
-    var base = new Base(airtable, baseId);
+Base.createFunctor = function(airtable, baseId, debug) {
+    if (typeof debug !== 'boolean') {
+        debug = false;
+    }
+    var base = new Base(airtable, baseId, debug);
     var baseFn = function() {
         return base.doCall.apply(base, arguments);
     };


### PR DESCRIPTION
This PR adds _debug mode_ at the `request` module in `base.js`, however I couldn't find a way to test it, as the module is an variable at the base.js.
If anyone can test it, I would appreciate.