### PR TITLE
Add base.js to coverage report 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ is equivalent to
 table.select().firstPage().then(result => { ... })
 ```
 
-# Where are the tests?
+# Tests
 
-Our tests live in a different repository and tests run on every `git push`.
-We strive to have all of the API covered along with all API error conditions.
-If you hit something that's not right, be sure to email support@airtable.com or
-open a GitHub Issue.
+Tests are run via `npm run test`.
+
+We strive for 100% test coverage. Some aspects may not be testable or suitable
+for test coverage. The tooling supports ignoring specific parts of a file
+[documented here](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines); use that as appropriate.
+
+When you run the tests a coverage report will be generated at `./coverage/lcov-report/index.html`
+which you can access in the browser for line by line reporting.

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,4 +1,3 @@
-// istanbul ignore file
 'use strict';
 
 var forEach = require('lodash/forEach');

--- a/test/airtable.test.js
+++ b/test/airtable.test.js
@@ -60,12 +60,14 @@ describe('Airtable', function() {
             });
         });
 
-        it('returns a Base instance configured with the given ID', function() {
+        it('returns a Base function configured with the given base and access to tables', function() {
             try {
                 Airtable.apiKey = 'keyJkl';
-                var base = Airtable.base('abaseid');
+                var baseFn = Airtable.base('abaseid');
 
-                expect(base.getId()).toBe('abaseid');
+                expect(baseFn.getId()).toBe('abaseid');
+                expect(baseFn('atablename').name).toBe('atablename');
+                expect(baseFn('atablename').id).toBe(null);
             } finally {
                 delete Airtable.apiKey;
             }

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -9,13 +9,14 @@ describe('Base', function() {
     var teardownAsync;
     var testExpressApp;
     var fakeBase;
+    var baseId = 'app123';
 
     beforeEach(function() {
         return testHelpers.getMockEnvironmentAsync().then(function(env) {
             airtable = env.airtable;
             teardownAsync = env.teardownAsync;
             testExpressApp = env.testExpressApp;
-            fakeBase = airtable.base('app123');
+            fakeBase = airtable.base(baseId);
         });
     });
 
@@ -519,6 +520,12 @@ describe('Base', function() {
                     });
                 })
                 .catch(done);
+        });
+    });
+
+    describe('#getId', function() {
+        it('gets the id', function() {
+            expect(fakeBase.getId()).toBe(baseId);
         });
     });
 });


### PR DESCRIPTION
- Added some documentation about testing to README 
- Added a [editorconfig](https://editorconfig.org/) to ensure spacing works correctly by default across editors
- Added base.js to coverage report
- It was mostly already well tested
- There were some functions prefixed with `_` that weren't tested but I believe they are meant to be private and not tested so I ignored them
- Added a test for `getId`
- Added coverage for `#doCall` and `#createFunctor` because it is doubtful that they really are meant to be part of a public interface and would probably not be considered a breaking change if they were changed. `#doCall` isn't actually called outside of `table.js` and probably should be prefixed by an underscore. 