### PR TITLE
Add test coverage for `lib/table.js`

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -1,4 +1,3 @@
-// istanbul ignore file
 'use strict';
 
 var isArray = require('lodash/isArray');

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var testHelpers = require('./test_helpers');
+
+describe('record retrival', function() {
+    var airtable;
+    var testExpressApp;
+    var teardownAsync;
+
+    beforeAll(function() {
+        return testHelpers.getMockEnvironmentAsync().then(function(env) {
+            airtable = env.airtable;
+            testExpressApp = env.testExpressApp;
+            teardownAsync = env.teardownAsync;
+        });
+    });
+
+    afterAll(function() {
+        return teardownAsync();
+    });
+
+    it('can find one record', function() {
+        var recordId = 'record1';
+
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table/record1?');
+            res.json({
+                id: req.params.recordId,
+                fields: {Name: 'Rebecca'},
+                createdTime: '2020-04-20T16:20:00.000Z',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .find(recordId)
+            .then(function(foundRecord) {
+                expect(foundRecord.id).toBe(recordId);
+                expect(foundRecord.get('Name')).toBe('Rebecca');
+            });
+    });
+});

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var testHelpers = require('./test_helpers');
+
+describe('list records', function() {
+    var airtable;
+    var testExpressApp;
+    var teardownAsync;
+
+    beforeAll(function() {
+        return testHelpers.getMockEnvironmentAsync().then(function(env) {
+            airtable = env.airtable;
+            testExpressApp = env.testExpressApp;
+            teardownAsync = env.teardownAsync;
+        });
+    });
+
+    afterAll(function() {
+        return teardownAsync();
+    });
+
+    it('lists records with a limit and offset without opts', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table/?limit=50&offset=offset000');
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(50, 'offset000', function(err, records, offset) {
+                expect(err).toBeNull();
+                expect(records.length).toBe(1);
+                expect(records[0].getId()).toBe('recordA');
+                expect(records[0].get('Name')).toBe('Rebecca');
+                expect(offset).toBe('offsetABC');
+                done();
+            });
+    });
+
+    it('lists records with a limit, offset, and opts', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe(
+                '/v0/app123/Table/?limit=50&offset=offset000&otherOptions=getpassedalong'
+            );
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(50, 'offset000', {otherOptions: 'getpassedalong'}, function(
+                err,
+                records,
+                offset
+            ) {
+                expect(err).toBeNull();
+                expect(records.length).toBe(1);
+                expect(records[0].getId()).toBe('recordA');
+                expect(records[0].get('Name')).toBe('Rebecca');
+                expect(offset).toBe('offsetABC');
+                done();
+            });
+    });
+
+    it('can throw an error if list fails', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            res.status(402).json({
+                error: {message: 'foo bar'},
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(50, 'offset000', function(err, records, offset) {
+                expect(err).not.toBeNull();
+                expect(records).toBeUndefined();
+                expect(offset).toBeUndefined();
+                done();
+            });
+    });
+});

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -100,4 +100,130 @@ describe('list records', function() {
                 done();
             });
     });
+
+    it('iterates through each record with opts', function(done) {
+        var json = {
+            records: [
+                {
+                    id: 'recordA',
+                    fields: {Name: 'Rebecca'},
+                    createdTime: '2020-04-20T16:20:00.000Z',
+                },
+            ],
+        };
+
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table/?limit=100&opts=arepassedalong');
+            res.json(json);
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .forEach(
+                {opts: 'arepassedalong'},
+                function(record) {
+                    expect(record.getId()).toBe('recordA');
+                    expect(record.get('Name')).toBe('Rebecca');
+                },
+                function() {
+                    done();
+                }
+            );
+    });
+
+    it('iterates through each record without opts', function(done) {
+        var json = {
+            records: [
+                {
+                    id: 'recordA',
+                    fields: {Name: 'Rebecca'},
+                    createdTime: '2020-04-20T16:20:00.000Z',
+                },
+            ],
+        };
+
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table/?limit=100');
+            res.json(json);
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .forEach(
+                function(record) {
+                    expect(record.getId()).toBe('recordA');
+                    expect(record.get('Name')).toBe('Rebecca');
+                },
+                function() {
+                    done();
+                }
+            );
+    });
+
+    it('can throw an error if forEach fails', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            res.status(402).json({
+                error: {message: 'foo bar'},
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .forEach(
+                {opts: 'arepassedalong'},
+                function() {},
+                function(err) {
+                    expect(err).not.toBeNull();
+                    done();
+                }
+            );
+    });
+
+    it('iterates through each record and handles pagination', function(done) {
+        var json = {
+            records: [
+                {
+                    id: 'recordA',
+                    fields: {Name: 'Rebecca'},
+                    createdTime: '2020-04-20T16:20:00.000Z',
+                },
+            ],
+            offset: 'offset123',
+        };
+
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table/?limit=100&opts=arepassedalong');
+            res.json(json);
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .forEach(
+                {opts: 'arepassedalong'},
+                function(record) {
+                    expect(record.getId()).toBe('recordA');
+                    expect(record.get('Name')).toBe('Rebecca');
+
+                    // Reset API response to handle the paginated call
+                    testExpressApp.set('handler override', function(req, res) {
+                        expect(req.method).toBe('GET');
+                        expect(req.url).toBe(
+                            '/v0/app123/Table/?limit=100&offset=offset123&opts=arepassedalong'
+                        );
+                        delete json.offset;
+                        res.json(json);
+                    });
+                },
+                function() {
+                    done();
+                }
+            );
+    });
 });

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+var testHelpers = require('./test_helpers');
+
+describe('record selection', function() {
+    var airtable;
+    var testExpressApp;
+    var teardownAsync;
+
+    beforeAll(function() {
+        return testHelpers.getMockEnvironmentAsync().then(function(env) {
+            airtable = env.airtable;
+            testExpressApp = env.testExpressApp;
+            teardownAsync = env.teardownAsync;
+        });
+    });
+
+    afterAll(function() {
+        return teardownAsync();
+    });
+
+    it('selects records without params', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table?');
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .select()
+            .eachPage(function page(records, fetchNextPage) {
+                records.forEach(function(record) {
+                    expect(record.id).toBe('recordA');
+                    expect(record.get('Name')).toBe('Rebecca');
+                });
+                done();
+            });
+    });
+
+    it('selects records with valid params', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe(
+                '/v0/app123/Table?maxRecords=50&sort%5B0%5D%5Bfield%5D=Name&sort%5B0%5D%5Bdirection%5D=desc'
+            );
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .select({maxRecords: 50, sort: [{field: 'Name', direction: 'desc'}]})
+            .eachPage(function page(records, fetchNextPage) {
+                records.forEach(function(record) {
+                    expect(record.id).toBe('recordA');
+                    expect(record.get('Name')).toBe('Rebecca');
+                });
+                done();
+            });
+    });
+
+    it('selects records filters out invalid parameters and extra arguments without erroring', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table?');
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .select({ignoredParam: 'ignore me'}, {anotherIgnored: 'param'})
+            .eachPage(function page(records, fetchNextPage) {
+                records.forEach(function(record) {
+                    expect(record.id).toBe('recordA');
+                    expect(record.get('Name')).toBe('Rebecca');
+                });
+                done();
+            });
+    });
+
+    it('selects records errors on invalid parameters', function() {
+        return expect(() => {
+            airtable
+                .base('app123')
+                .table('Table')
+                .select({maxRecords: 'should not be a string'});
+        }).toThrow();
+    });
+
+    it('selects records errors when the params are not a plain object', function() {
+        return expect(() => {
+            airtable
+                .base('app123')
+                .table('Table')
+                .select('?invalid=params');
+        }).toThrow();
+    });
+});

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var testHelpers = require('./test_helpers');
+
+describe('Table', function() {
+    var airtable;
+    var teardownAsync;
+
+    beforeAll(function() {
+        return testHelpers.getMockEnvironmentAsync().then(function(env) {
+            airtable = env.airtable;
+            teardownAsync = env.teardownAsync;
+        });
+    });
+
+    afterAll(function() {
+        return teardownAsync();
+    });
+
+    it('throws an error without a table reference', function() {
+        return expect(() => {
+            airtable.base('app123').table();
+        }).toThrow();
+    });
+});


### PR DESCRIPTION
- Add 100% test coverage
- Follow existing pattern of more "integration" style test where each operation that has its own test file and the file tests the in results of interacting with the fake API directly (as opposed to a true unit test that would mock out `Tables`'s interactions with `Record` and `Query`) 
- The `select`, `update`, and `create` methods were already pretty extensively tested using hard coded return values in the mock API express app. I added tests for error cases using the existing "handler override" functionality. Since the "handler override" is only resets on `tearDownAsync` all cleanup and setup needs to be down in these test files on `each` test. This probably makes the test slower. I could instead add some mechanism to reset the `handler` after each run.  