### PR TITLE
Complete tests for http_headers

### DIFF
--- a/lib/http_headers.js
+++ b/lib/http_headers.js
@@ -1,4 +1,3 @@
-// istanbul ignore file
 var forEach = require('lodash/forEach');
 
 var isBrowser = typeof window !== 'undefined';
@@ -25,6 +24,7 @@ HttpHeaders.prototype.toJSON = function() {
     var result = {};
     forEach(this._headersByLowercasedKey, function(headerDefinition, lowercasedKey) {
         var headerKey;
+        /* istanbul ignore next */
         if (isBrowser && lowercasedKey === 'user-agent') {
             // Some browsers do not allow overriding the user agent.
             // https://github.com/Airtable/airtable.js/issues/52

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -162,6 +162,21 @@ describe('Base', function() {
                         expect(value === 'bar' || value === 'baz').toBeTruthy();
                     });
             });
+
+            it('allows headers with custom user agent', function() {
+                return fakeBase
+                    .makeRequest({
+                        headers: {
+                            Authorization: 'foo',
+                            'X-Airtable-User-Agent': 'bazz',
+                        },
+                    })
+                    .then(function() {
+                        const req = testExpressApp.get('most recent request');
+                        expect(req.get('authorization')).toEqual('foo');
+                        expect(req.get('user-agent')).toEqual('bazz');
+                    });
+            });
         });
 
         describe('request body', function() {


### PR DESCRIPTION
- Ignore lack of test for isBrowser because isn't very important and is
hard to test because `window` is called when the file is required.
- Add test for custom user-agent header