### PR TITLE
Add test coverage for `lib/run_action.js`

### DIFF
--- a/lib/run_action.js
+++ b/lib/run_action.js
@@ -1,4 +1,3 @@
-// istanbul ignore file
 'use strict';
 
 var exponentialBackoffWithJitter = require('./exponential_backoff_with_jitter');

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -16,6 +16,7 @@ describe('record retrival', function() {
     });
 
     afterAll(function() {
+        delete global.x;
         return teardownAsync();
     });
 
@@ -25,6 +26,32 @@ describe('record retrival', function() {
         testExpressApp.set('handler override', function(req, res) {
             expect(req.method).toBe('GET');
             expect(req.url).toBe('/v0/app123/Table/record1?');
+            expect(req.get('user-agent')).toMatch(/Airtable.js/);
+            res.json({
+                id: req.params.recordId,
+                fields: {Name: 'Rebecca'},
+                createdTime: '2020-04-20T16:20:00.000Z',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .find(recordId)
+            .then(function(foundRecord) {
+                expect(foundRecord.id).toBe(recordId);
+                expect(foundRecord.get('Name')).toBe('Rebecca');
+            });
+    });
+
+    it('set the correct headers in a browser', function() {
+        global.window = {};
+        var recordId = 'record1';
+
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe('/v0/app123/Table/record1?');
+            expect(req.get('x-airtable-user-agent')).toMatch(/Airtable.js/);
             res.json({
                 id: req.params.recordId,
                 fields: {Name: 'Rebecca'},

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -16,7 +16,7 @@ describe('record retrival', function() {
     });
 
     afterAll(function() {
-        delete global.x;
+        delete global.window;
         return teardownAsync();
     });
 

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -69,7 +69,7 @@ describe('record retrival', function() {
             });
     });
 
-    it('can handle an error', function(done) {
+    it('can handle an error', function() {
         testExpressApp.set('handler override', function(req, res) {
             res.status(402).json({
                 error: {message: 'foo bar'},
@@ -87,12 +87,11 @@ describe('record retrival', function() {
                 function(err) {
                     expect(err.statusCode).toBe(402);
                     expect(err.message).toBe('foo bar');
-                    done();
                 }
             );
     });
 
-    it('can find after a retry if rate limited', function(done) {
+    it('can find after a retry if rate limited', function() {
         var apiCallCount = 0;
         var recordId = 'record1';
 
@@ -120,7 +119,6 @@ describe('record retrival', function() {
             .then(function(foundRecord) {
                 expect(foundRecord.id).toBe(recordId);
                 expect(foundRecord.get('Name')).toBe('Rebecca');
-                done();
             });
     });
 });


### PR DESCRIPTION
`run_action` didn't have any unit tests but was already pretty throughly tested because almost all methods use it run make their API requests. I didn't add unit testing I just added the missing pieaces of coverage:
- Dealing with retries
- Dealing with the user header if requests are from the browser