### PR TITLE
Move promise test ignore from file to next

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,5 +1,5 @@
-// istanbul ignore file
 /* global Promise */
 var polyfill = require('es6-promise');
 
+// istanbul ignore next
 module.exports = typeof Promise === 'undefined' ? polyfill.Promise : Promise;


### PR DESCRIPTION
It just adds a polyfill and cannot be tested easily because it it required before the test starts.