### PR TITLE
CI: Limit code linting to a single v. of Node.js

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm test
+    - run: npm run lint
+      if: ${{ matrix.node-version == '12.x' }}
+    - run: npm run coverage
       env:
         CI: true


### PR DESCRIPTION
The static code analyzer is unlikely to uncover different issues across
versions of Node.js. A report comprised of results from many versions
will generally be redundant.

Reconfigure the service to lint the code in the latest verion of Node.js
only.