### PR TITLE
Remove Promise Polyfill

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -108,5 +108,8 @@
         "space-unary-ops": "warn",
         "spaced-comment": "warn",
         "yoda": "warn"
+    },
+    "globals": {
+        "Promise": "writable"
     }
 }

--- a/lib/base.js
+++ b/lib/base.js
@@ -14,7 +14,6 @@ var HttpHeaders = require('./http_headers');
 var runAction = require('./run_action');
 var packageVersion = require('./package_version');
 var exponentialBackoffWithJitter = require('./exponential_backoff_with_jitter');
-var Promise = require('./promise');
 
 var userAgent = 'Airtable.js/' + packageVersion;
 

--- a/lib/callback_to_promise.js
+++ b/lib/callback_to_promise.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('./promise');
-
 /**
  * Given a function fn that takes a callback as its last argument, returns
  * a new version of the function that takes the callback optionally. If

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,5 +1,0 @@
-/* global Promise */
-var polyfill = require('es6-promise');
-
-// istanbul ignore next
-module.exports = typeof Promise === 'undefined' ? polyfill.Promise : Promise;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,11 +2405,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.4.0",
-    "es6-promise": "4.2.8",
     "lodash": "4.17.15",
     "node-fetch": "^2.6.0"
   },


### PR DESCRIPTION
The Promise polyfill is not needed with the outlined techinal
requirements for node or browser support.

Closes https://github.com/Airtable/airtable.js/issues/179

A follow up to: https://github.com/Airtable/airtable.js/pull/191