### PR TITLE
[SECURITY] Update lodash to newer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4812,9 +4812,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.4.0",
-    "lodash": "4.17.15",
+    "lodash": "4.17.19",
     "node-fetch": "^2.6.0"
   },
   "main": "./lib/airtable.js",


### PR DESCRIPTION
There is a security advisory for this lodash version, so it should be updated. 😺 

https://www.npmjs.com/advisories/1523