### PR TITLE
fix: correct imports for node (fixes #204)

### DIFF
--- a/lib/abort-controller.js
+++ b/lib/abort-controller.js
@@ -1,6 +1,6 @@
 // istanbul ignore file
 if (typeof window === 'undefined') {
-    module.exports = require('abort-controller');
+    module.exports = require('abort-controller').AbortController;
 } else {
     if ('signal' in new Request('')) {
         module.exports = window.AbortController;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,4 +1,4 @@
-var fetch = require('node-fetch');
+var fetch = require('node-fetch').default;
 
 // istanbul ignore next
 module.exports = typeof window === 'undefined' ? fetch : window.fetch;


### PR DESCRIPTION
This fixes a couple of errors caused by the incorrect require statements being used for node:

`TypeError: AbortController is not a constructor`: require('abort-controller') returns module object, not default export.

`TypeError: fetch is not a function`: require('node-fetch') returns module object, not default export.