### PR TITLE
Unpin dependency on Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^14.0.14",
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.4.0",
-    "lodash": "4.17.19",
+    "lodash": "^4.17.19",
     "node-fetch": "^2.6.0"
   },
   "main": "./lib/airtable.js",


### PR DESCRIPTION
Closes https://github.com/Airtable/airtable.js/issues/202.

This allows Lodash to be deduped when the consumer (or another dependency of the consumer) depends on a newer version of Lodash than Airtable does. It also allows `npm audit fix` to install a newer version of Lodash if a vulnerability has been reported and a newer version has been published, rather than requiring a new release of Airtable.

Currently, Lodash is the only Airtable dependency that is pinned to an exact version, so I'm guessing it's an oversight.