### PR TITLE
Widen dependency range on @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "rm -rf lib/* && tsc && grunt browserify"
   },
   "dependencies": {
-    "@types/node": "^14.0.14",
+    "@types/node": ">=8.0.0 <15",
     "abort-controller": "^3.0.0",
     "abortcontroller-polyfill": "^1.4.0",
     "lodash": "4.17.19",


### PR DESCRIPTION
This library shouldn't depend on `@types/node@^14.0.14` because the `engines` field of its package.json claims that it's compatible with any Node version over 8.0.0:

https://github.com/Airtable/airtable.js/blob/2549f7a9c6bbd00bdfed0975c984f5ea2815fae3/package.json#L72-L74

`@types/node` declares global typings, so consumers using, e.g., Node v10, don't generally want the typings for a newer version of Node in their environment.

This PR widens the range to include the typings for any Node version between 8 and 14, inclusive. This will generally mean that the most recent version gets installed if the project doesn't already depend on Node typings, but otherwise it will resolve to whatever typings are already installed. The range could alternatively be adjusted to `>=8.0.0` to match the `engines` field but that's slightly less safe.

Alternatively, if the Node typings aren't actually referenced by the published typings, they could be moved to `devDependencies` instead.