### PR TITLE
fix: error handler in updating an array

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -885,13 +885,12 @@ var Table = /** @class */ (function () {
             done = optsOrDone || recordDataOrOptsOrDone;
             var method = isDestructiveUpdate ? 'put' : 'patch';
             var requestData = assign_1.default({ records: recordsData }, opts);
-            this._base.runAction(method, "/" + this._urlEncodedNameOrId() + "/", {}, requestData, function (err, resp, _a) {
-                var records = _a.records;
+            this._base.runAction(method, "/" + this._urlEncodedNameOrId() + "/", {}, requestData, function (err, resp, body) {
                 if (err) {
                     done(err);
                     return;
                 }
-                var result = records.map(function (record) {
+                var result = body.records.map(function (record) {
                     return new record_1.default(_this, record.id, record);
                 });
                 done(null, result);

--- a/src/table.ts
+++ b/src/table.ts
@@ -242,13 +242,13 @@ class Table {
                 `/${this._urlEncodedNameOrId()}/`,
                 {},
                 requestData,
-                (err, resp, {records}) => {
+                (err, resp, body) => {
                     if (err) {
                         done(err);
                         return;
                     }
 
-                    const result = records.map(record => {
+                    const result = body.records.map(record => {
                         return new Record(this, record.id, record);
                     });
                     done(null, result);

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -223,6 +223,36 @@ describe('record updates', function() {
                     }
                 );
         });
+
+        it('can throw an error if a multi-record update call fails due to network error', function(done) {
+            testExpressApp.set('handler override', function(req, res) {
+                res.status(522).end();
+            });
+
+            return airtable
+                .base('app123')
+                .table('Table')
+                .update([
+                    {
+                        id: 'rec123',
+                        fields: {foo: 'boo'},
+                    },
+                    {
+                        id: 'rec456',
+                        fields: {bar: 'yar'},
+                    },
+                ])
+                .then(
+                    function() {
+                        throw new Error('Promise unexpectly fufilled.');
+                    },
+                    function(err) {
+                        expect(err.statusCode).toBe(522);
+                        expect(err.message).toBe('An unexpected error occurred');
+                        done();
+                    }
+                );
+        });
     });
 
     describe('destructive updates', function() {


### PR DESCRIPTION
noticed that body is destructed before check for an error
https://github.com/Airtable/airtable.js/blob/master/src/table.ts#L245

in a case when body has no `records` it would throw `TypeError: Cannot read property 'records' of undefined`
