### PR TITLE
Match `@types/airtable` types and fix type lint warnings

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -9,8 +9,9 @@ else if ('signal' in new Request('')) {
     AbortController = window.AbortController;
 }
 else {
-    /* eslint-disable-next-line */
+    /* eslint-disable @typescript-eslint/no-var-requires */
     var polyfill = require('abortcontroller-polyfill/dist/cjs-ponyfill');
+    /* eslint-enable @typescript-eslint/no-var-requires */
     AbortController = polyfill.AbortController;
 }
 module.exports = AbortController;
@@ -86,7 +87,6 @@ var Base = /** @class */ (function () {
             fetch_1.default(url, requestOptions)
                 .then(function (resp) {
                 clearTimeout(timeout);
-                resp.statusCode = resp.status;
                 if (resp.status === 429 && !_this._airtable._noRetryIfRateLimited) {
                     var numAttempts_1 = get_1.default(options, '_numAttempts', 0);
                     var backoffDelayMs = exponential_backoff_with_jitter_1.default(numAttempts_1);
@@ -219,20 +219,26 @@ module.exports = Base;
  * the function is not called with a callback for the last argument, the
  * function will return a promise instead.
  */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 function callbackToPromise(fn, context, callbackArgIndex) {
     if (callbackArgIndex === void 0) { callbackArgIndex = void 0; }
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
     return function () {
+        var callArgs = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            callArgs[_i] = arguments[_i];
+        }
         var thisCallbackArgIndex;
         if (callbackArgIndex === void 0) {
             // istanbul ignore next
-            thisCallbackArgIndex = arguments.length > 0 ? arguments.length - 1 : 0;
+            thisCallbackArgIndex = callArgs.length > 0 ? callArgs.length - 1 : 0;
         }
         else {
             thisCallbackArgIndex = callbackArgIndex;
         }
-        var callbackArg = arguments[thisCallbackArgIndex];
+        var callbackArg = callArgs[thisCallbackArgIndex];
         if (typeof callbackArg === 'function') {
-            fn.apply(context, arguments);
+            fn.apply(context, callArgs);
             return void 0;
         }
         else {
@@ -240,9 +246,9 @@ function callbackToPromise(fn, context, callbackArgIndex) {
             // If an explicit callbackArgIndex is set, but the function is called
             // with too few arguments, we want to push undefined onto args so that
             // our constructed callback ends up at the right index.
-            var argLen = Math.max(arguments.length, thisCallbackArgIndex);
+            var argLen = Math.max(callArgs.length, thisCallbackArgIndex);
             for (var i = 0; i < argLen; i++) {
-                args_1.push(arguments[i]);
+                args_1.push(callArgs[i]);
             }
             return new Promise(function (resolve, reject) {
                 args_1.push(function (err, result) {
@@ -309,13 +315,13 @@ module.exports = exponentialBackoffWithJitter;
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
+// istanbul ignore file
 var node_fetch_1 = __importDefault(require("node-fetch"));
-module.exports = (
-// istanbul ignore next
-typeof window === 'undefined' ? node_fetch_1.default : window.fetch.bind(window));
+module.exports = typeof window === 'undefined' ? node_fetch_1.default : window.fetch.bind(window);
 
 },{"node-fetch":20}],8:[function(require,module,exports){
 "use strict";
+/* eslint-enable @typescript-eslint/no-explicit-any */
 function has(object, property) {
     return Object.prototype.hasOwnProperty.call(object, property);
 }
@@ -378,6 +384,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 var isArray_1 = __importDefault(require("lodash/isArray"));
 var forEach_1 = __importDefault(require("lodash/forEach"));
 var isNil_1 = __importDefault(require("lodash/isNil"));
+/* eslint-enable @typescript-eslint/no-explicit-any */
 // Adapted from jQuery.param:
 // https://github.com/jquery/jquery/blob/2.2-stable/src/serialize.js
 function buildParams(prefix, obj, addFn) {
@@ -884,7 +891,7 @@ var Table = /** @class */ (function () {
         if (isArray_1.default(recordsDataOrRecordId)) {
             var recordsData = recordsDataOrRecordId;
             opts = isPlainObject_1.default(recordDataOrOptsOrDone) ? recordDataOrOptsOrDone : {};
-            done = optsOrDone || recordDataOrOptsOrDone;
+            done = (optsOrDone || recordDataOrOptsOrDone);
             var method = isDestructiveUpdate ? 'put' : 'patch';
             var requestData = assign_1.default({ records: recordsData }, opts);
             this._base.runAction(method, "/" + this._urlEncodedNameOrId() + "/", {}, requestData, function (err, resp, body) {
@@ -902,7 +909,7 @@ var Table = /** @class */ (function () {
             var recordId = recordsDataOrRecordId;
             var recordData = recordDataOrOptsOrDone;
             opts = isPlainObject_1.default(optsOrDone) ? optsOrDone : {};
-            done = done || optsOrDone;
+            done = (done || optsOrDone);
             var record = new record_1.default(this, recordId);
             if (isDestructiveUpdate) {
                 record.putUpdate(recordData, opts, done);
@@ -992,6 +999,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 var includes_1 = __importDefault(require("lodash/includes"));
 var isArray_1 = __importDefault(require("lodash/isArray"));
+/* eslint-enable @typescript-eslint/no-explicit-any */
 function check(fn, error) {
     return function (value) {
         if (fn(value)) {

--- a/src/abort-controller.ts
+++ b/src/abort-controller.ts
@@ -5,8 +5,9 @@ if (typeof window === 'undefined') {
 } else if ('signal' in new Request('')) {
     AbortController = window.AbortController;
 } else {
-    /* eslint-disable-next-line */
+    /* eslint-disable @typescript-eslint/no-var-requires */
     const polyfill = require('abortcontroller-polyfill/dist/cjs-ponyfill');
+    /* eslint-enable @typescript-eslint/no-var-requires */
     AbortController = polyfill.AbortController;
 }
 

--- a/src/airtable.ts
+++ b/src/airtable.ts
@@ -1,9 +1,17 @@
 import Base from './base';
-import Record from './record';
-import Table from './table';
+import AirtableRecord from './record';
+import AirtableTable from './table';
 import AirtableError from './airtable_error';
+import AirtableQuery from './query';
 import {AirtableBase} from './airtable_base';
-import type {ObjectMap} from './object_map';
+import {ObjectMap} from './object_map';
+import {FieldSet as AirtableFieldSet} from './field_set';
+import {Collaborator as AirtableCollaborator} from './collaborator';
+import {Thumbnail as AirtableThumbnail} from './thumbnail';
+import {Attachment as AirtableAttachment} from './attachment';
+import {Records as AirtableRecords} from './records';
+import {RecordData as AirtableRecordData} from './record_data';
+import {QueryParams as AirtableSelectOptions} from './query_params';
 
 type CustomHeaders = ObjectMap<string, string | number | boolean>;
 
@@ -18,8 +26,8 @@ class Airtable {
     requestTimeout: number;
 
     static Base = Base;
-    static Record = Record;
-    static Table = Table;
+    static Record = AirtableRecord;
+    static Table = AirtableTable;
     static Error = AirtableError;
 
     static apiKey: string;
@@ -27,16 +35,7 @@ class Airtable {
     static endpointUrl: string;
     static noRetryIfRateLimited: boolean;
 
-    constructor(
-        opts: {
-            apiKey?: string;
-            apiVersion?: string;
-            customHeaders?: CustomHeaders;
-            endpointUrl?: string;
-            noRetryIfRateLimited?: boolean;
-            requestTimeout?: number;
-        } = {}
-    ) {
+    constructor(opts: Airtable.AirtableOptions = {}) {
         const defaultConfig = Airtable.default_config();
 
         const apiVersion = opts.apiVersion || Airtable.apiVersion || defaultConfig.apiVersion;
@@ -72,17 +71,11 @@ class Airtable {
         }
     }
 
-    base(baseId: string): AirtableBase {
+    base(baseId: string): Airtable.Base {
         return Base.createFunctor(this, baseId);
     }
 
-    static default_config(): ({
-        endpointUrl: string,
-        apiVersion: string,
-        apiKey: string,
-        noRetryIfRateLimited: boolean,
-        requestTimeout: number,
-    }) {
+    static default_config(): Airtable.AirtableOptions {
         return {
             endpointUrl: process.env.AIRTABLE_ENDPOINT_URL || 'https://api.airtable.com',
             apiVersion: '0.1.0',
@@ -92,21 +85,48 @@ class Airtable {
         };
     }
 
-    static configure({apiKey, endpointUrl, apiVersion, noRetryIfRateLimited}: {
-        apiKey: string,
-        endpointUrl: string,
-        apiVersion: string,
-        noRetryIfRateLimited: boolean,
-    }): void {
+    static configure({
+        apiKey,
+        endpointUrl,
+        apiVersion,
+        noRetryIfRateLimited,
+    }: Pick<Airtable.AirtableOptions, 'apiKey' | 'endpointUrl' | 'apiVersion' | 'noRetryIfRateLimited'>): void {
         Airtable.apiKey = apiKey;
         Airtable.endpointUrl = endpointUrl;
         Airtable.apiVersion = apiVersion;
         Airtable.noRetryIfRateLimited = noRetryIfRateLimited;
     }
 
-    static base(baseId: string): AirtableBase {
+    static base(baseId: string): Airtable.Base {
         return new Airtable().base(baseId);
     }
+}
+
+/* eslint-disable no-redeclare, @typescript-eslint/no-namespace */
+namespace Airtable {
+    /* eslint-enable no-redeclare, @typescript-eslint/no-namespace */
+    export interface AirtableOptions {
+        apiKey?: string;
+        apiVersion?: string;
+        customHeaders?: CustomHeaders;
+        endpointUrl?: string;
+        noRetryIfRateLimited?: boolean;
+        requestTimeout?: number;
+    }
+
+    export type FieldSet = AirtableFieldSet;
+    export type Collaborator = AirtableCollaborator;
+    export type Attachment = AirtableAttachment;
+    export type Thumbnail = AirtableThumbnail;
+
+    export type Base = AirtableBase;
+    export type Error = AirtableError;
+    export type Table<TFields extends AirtableFieldSet> = AirtableTable<TFields>;
+    export type SelectOptions<TFields> = AirtableSelectOptions<TFields>;
+    export type Query<TFields extends AirtableFieldSet> = AirtableQuery<TFields>;
+    export type Record<TFields extends AirtableFieldSet> = AirtableRecord<TFields>;
+    export type RecordData<TFields extends AirtableFieldSet> = AirtableRecordData<TFields>;
+    export type Records<TFields extends AirtableFieldSet> = AirtableRecords<TFields>;
 }
 
 export = Airtable;

--- a/src/airtable_base.ts
+++ b/src/airtable_base.ts
@@ -1,9 +1,10 @@
 import Table from './table';
 import Base from './base';
+import {FieldSet} from './field_set';
 
-export type AirtableBase = {
-    (tableName: string): Table;
+export interface AirtableBase {
+    <TFields extends FieldSet>(tableName: string): Table<TFields>;
     getId: Base['getId'];
     makeRequest: Base['makeRequest'];
     table: Base['table'];
-};
+}

--- a/src/airtable_request_options.ts
+++ b/src/airtable_request_options.ts
@@ -1,8 +1,0 @@
-export type AirtableRequestOptions = {
-    method?: string;
-    path?: string;
-    qs?: Record<string, string>;
-    headers?: Record<string, string>;
-    body?;
-    _numAttempts?: number;
-};

--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -1,0 +1,14 @@
+import {Thumbnail} from './thumbnail';
+
+export interface Attachment {
+    id: string;
+    url: string;
+    filename: string;
+    size: number;
+    type: string;
+    thumbnails?: {
+        small: Thumbnail;
+        large: Thumbnail;
+        full: Thumbnail;
+    };
+}

--- a/src/callback_to_promise.ts
+++ b/src/callback_to_promise.ts
@@ -4,27 +4,29 @@
  * the function is not called with a callback for the last argument, the
  * function will return a promise instead.
  */
-function callbackToPromise(fn, context, callbackArgIndex = void 0): any {
-    return function() {
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
+function callbackToPromise(fn: any, context: any, callbackArgIndex: number = void 0): any {
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
+    return function(...callArgs: unknown[]) {
         let thisCallbackArgIndex;
         if (callbackArgIndex === void 0) {
             // istanbul ignore next
-            thisCallbackArgIndex = arguments.length > 0 ? arguments.length - 1 : 0;
+            thisCallbackArgIndex = callArgs.length > 0 ? callArgs.length - 1 : 0;
         } else {
             thisCallbackArgIndex = callbackArgIndex;
         }
-        const callbackArg = arguments[thisCallbackArgIndex];
+        const callbackArg = callArgs[thisCallbackArgIndex];
         if (typeof callbackArg === 'function') {
-            fn.apply(context, arguments);
+            fn.apply(context, callArgs);
             return void 0;
         } else {
             const args = [];
             // If an explicit callbackArgIndex is set, but the function is called
             // with too few arguments, we want to push undefined onto args so that
             // our constructed callback ends up at the right index.
-            const argLen = Math.max(arguments.length, thisCallbackArgIndex);
+            const argLen = Math.max(callArgs.length, thisCallbackArgIndex);
             for (let i = 0; i < argLen; i++) {
-                args.push(arguments[i]);
+                args.push(callArgs[i]);
             }
             return new Promise((resolve, reject) => {
                 args.push((err, result) => {

--- a/src/collaborator.ts
+++ b/src/collaborator.ts
@@ -1,0 +1,5 @@
+export interface Collaborator {
+    id: string;
+    email: string;
+    name: string;
+}

--- a/src/deprecate.ts
+++ b/src/deprecate.ts
@@ -11,8 +11,8 @@ const didWarnForDeprecation = {};
  *
  * @return a wrapped function
  */
-function deprecate(fn, key, message) {
-    return function(...args) {
+function deprecate<Args extends unknown[]>(fn: (...args: Args) => void, key: string, message: string): (...args: Args) => void {
+    return function(...args: Args): void {
         if (!didWarnForDeprecation[key]) {
             didWarnForDeprecation[key] = true;
             console.warn(message);

--- a/src/exponential_backoff_with_jitter.ts
+++ b/src/exponential_backoff_with_jitter.ts
@@ -1,7 +1,7 @@
 import internalConfig from './internal_config.json';
 
 // "Full Jitter" algorithm taken from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-function exponentialBackoffWithJitter(numberOfRetries: number) {
+function exponentialBackoffWithJitter(numberOfRetries: number): number {
     const rawBackoffTimeMs =
         internalConfig.INITIAL_RETRY_DELAY_IF_RATE_LIMITED * 2 ** numberOfRetries;
     const clippedBackoffTimeMs = Math.min(

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,6 +1,5 @@
+// istanbul ignore file
 import nodeFetch from 'node-fetch';
 
-export = (
-    // istanbul ignore next
-    typeof window === 'undefined' ? (nodeFetch as typeof fetch) : window.fetch.bind(window)
-);
+export =
+typeof window === 'undefined' ? (nodeFetch as typeof fetch) : window.fetch.bind(window);

--- a/src/field_set.ts
+++ b/src/field_set.ts
@@ -1,0 +1,14 @@
+import {Collaborator} from './collaborator';
+import {Attachment} from './attachment';
+
+export interface FieldSet {
+    [key: string]:
+        | undefined
+        | string
+        | number
+        | boolean
+        | Collaborator
+        | ReadonlyArray<Collaborator>
+        | ReadonlyArray<string>
+        | ReadonlyArray<Attachment>;
+}

--- a/src/has.ts
+++ b/src/has.ts
@@ -1,4 +1,8 @@
-function has<O, P extends string>(object: O, property: P): object is O & {[key in P]: any} {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type HasValue = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function has<O, P extends string>(object: O, property: P): object is O & {[key in P]: HasValue} {
     return Object.prototype.hasOwnProperty.call(object, property);
 }
 

--- a/src/http_headers.ts
+++ b/src/http_headers.ts
@@ -9,7 +9,7 @@ class HttpHeaders {
         this._headersByLowercasedKey = {};
     }
 
-    set(headerKey, headerValue) {
+    set(headerKey: string, headerValue: string): void {
         let lowercasedKey = headerKey.toLowerCase();
 
         if (lowercasedKey === 'x-airtable-user-agent') {
@@ -23,7 +23,7 @@ class HttpHeaders {
         };
     }
 
-    toJSON() {
+    toJSON(): {[key: string]: string} {
         const result = {};
         forEach(this._headersByLowercasedKey, (headerDefinition, lowercasedKey) => {
             let headerKey;

--- a/src/object_to_query_param_string.ts
+++ b/src/object_to_query_param_string.ts
@@ -2,6 +2,10 @@ import isArray from 'lodash/isArray';
 import forEach from 'lodash/forEach';
 import isNil from 'lodash/isNil';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type ToParamBody = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 // Adapted from jQuery.param:
 // https://github.com/jquery/jquery/blob/2.2-stable/src/serialize.js
 function buildParams(prefix, obj, addFn) {
@@ -31,7 +35,7 @@ function buildParams(prefix, obj, addFn) {
     }
 }
 
-function objectToQueryParamString(obj) {
+function objectToQueryParamString(obj: ToParamBody): string {
     const parts = [];
     const addFn = (key, value) => {
         value = isNil(value) ? '' : value;

--- a/src/package_version.ts
+++ b/src/package_version.ts
@@ -1,4 +1,5 @@
 // This will become package_version_browser.js when doing a browser build.
 // See <https://github.com/Airtable/airtable.js/pull/132> for more.
-// eslint-disable-next-line
+/* eslint-disable @typescript-eslint/no-var-requires */
 export = require('../package.json').version;
+/* eslint-enable @typescript-eslint/no-var-requires */

--- a/src/query_params.ts
+++ b/src/query_params.ts
@@ -42,6 +42,20 @@ export const paramValidators = {
     userLocale: check(isString, 'the value for `userLocale` should be a string'),
 };
 
-export type QueryParams = {
-    [key in keyof typeof paramValidators]?: Parameters<typeof paramValidators[key]>[0];
-};
+export interface SortParameter<TFields> {
+    field: keyof TFields;
+    direction?: 'asc' | 'desc';
+}
+
+export interface QueryParams<TFields> {
+    fields?: (keyof TFields)[];
+    filterByFormula?: string;
+    maxRecords?: number;
+    pageSize?: number;
+    offset?: number;
+    sort?: SortParameter<TFields>[];
+    view?: string;
+    cellFormat?: 'json' | 'string';
+    timeZone?: string;
+    userLocale?: string;
+}

--- a/src/record_data.ts
+++ b/src/record_data.ts
@@ -1,0 +1,4 @@
+export interface RecordData<TFields> {
+    id: string;
+    fields: TFields;
+}

--- a/src/records.ts
+++ b/src/records.ts
@@ -1,0 +1,4 @@
+import Record from './record';
+import {FieldSet} from './field_set';
+
+export type Records<TFields extends FieldSet> = ReadonlyArray<Record<TFields>>;

--- a/src/thumbnail.ts
+++ b/src/thumbnail.ts
@@ -1,0 +1,5 @@
+export interface Thumbnail {
+    url: string;
+    width: number;
+    height: number;
+}

--- a/src/typecheck.ts
+++ b/src/typecheck.ts
@@ -1,7 +1,11 @@
 import includes from 'lodash/includes';
 import isArray from 'lodash/isArray';
 
-function check<Value, Error>(fn: (value: any) => value is Value, error: Error) {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type CheckValue = any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function check<Value, Error>(fn: (value: CheckValue) => value is Value, error: Error) {
     return function(value: Value): {pass: true} | {pass: false; error: Error} {
         if (fn(value)) {
             return {pass: true};
@@ -15,8 +19,8 @@ check.isOneOf = function isOneOf(options) {
     return includes.bind(this, options);
 };
 
-check.isArrayOf = function<Value>(itemValidator: (value: any) => value is Value) {
-    return function(value: any): value is Value[] {
+check.isArrayOf = function<Value>(itemValidator: (value: CheckValue) => value is Value) {
+    return function(value: CheckValue): value is Value[] {
         return isArray(value) && value.every(itemValidator);
     };
 };

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -2,5 +2,11 @@
     "env": {
         "jest": true,
         "es6": true
+    },
+    "rules": {
+        "no-var": "off",
+        "prefer-rest-params": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/no-empty-function": "off"
     }
 }

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -112,8 +112,9 @@ function getMockEnvironmentAsync(options) {
     });
 
     // istanbul ignore next
-    // eslint-disable-next-line no-unused-vars
+    /* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
     app.use(function(err, req, res, next) {
+        /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
         console.error(err);
         res.status(500);
         res.json({


### PR DESCRIPTION
This PR fixes a few issues related to the exported typescript types and any lint warnings.

- Fix #220 
- Fix #210 

## Improve exported Types

This PR adds exports a namespace and many types like [`@types/airtable`].

### /src/airtable.ts

The `airtable.ts` file exports the Airtable class and namespace that will be imported from this package. At the bottom of the file the Airtable namespace exports the types like those in [`@types/airtable`]. The main difference is `Record` and `RecordData`. [`@types/airtable`] doesn't type Record's methods so it doesn't need to distinguish between data for updating records and `Record` instances that have methods to update that single record.

## lint warnings

### `@typescript-eslint/no-explicit-any`

Many source files have any typed arguments and returns. Most of the any typed arguments have been typed with generics. The remaining arguments have been aliased based on what kind of use that argument has. I hope these aliases make further work to type those easier by being able to iterate a search to those instances.

Here is an example from `record.ts` where it has two aliases. The first `RecordError` is used for `error` arguments in callbacks. The second `RecordJson` is for arguments with json results from api calls.

```ts
/* eslint-disable @typescript-eslint/no-explicit-any */
type RecordError = any;
type RecordJson = any;
/* eslint-enable @typescript-eslint/no-explicit-any */
```

### /src/*

The main change for most of these files is the addition of the generic `TFields` that extends `FieldSet`. These names match the same types in [`@types/airtable`].

In addition to the types like in [`@types/airtable`]. Many arguments and variables have also been type and are sometimes casted like in `table.ts`.

### /test/*

I didn't want to change any code in this directory. The only changes are to `/test/.eslintrc` and `/test/test_helpers.js`. Virtually all the warnings were from `no-var` and the remaining warning in `test_helpers` was `no-unused-vars`.

[`@types/airtable`]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/bacc18855fdebeec1d6edb68677100684254fa46/types/airtable/index.d.ts
