### PR TITLE
Fix "Failed to execute fetch on Window" for airtable.browser.js

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -310,7 +310,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 var node_fetch_1 = __importDefault(require("node-fetch"));
 module.exports = (
 // istanbul ignore next
-typeof window === 'undefined' ? node_fetch_1.default : fetch);
+typeof window === 'undefined' ? node_fetch_1.default : window.fetch.bind(window));
 
 },{"node-fetch":20}],8:[function(require,module,exports){
 "use strict";


### PR DESCRIPTION
Discussed in issue https://github.com/Airtable/airtable.js/issues/230

I assume this file is not supposed to be manually edited, but just creating this PR so others can make/see the required fix.

More useful probably is https://github.com/Airtable/airtable.js/pull/232