### PR TITLE
Bind fetch to window

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -310,7 +310,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 var node_fetch_1 = __importDefault(require("node-fetch"));
 module.exports = (
 // istanbul ignore next
-typeof window === 'undefined' ? node_fetch_1.default : fetch);
+typeof window === 'undefined' ? node_fetch_1.default : window.fetch.bind(window));
 
 },{"node-fetch":20}],8:[function(require,module,exports){
 "use strict";

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,5 +2,5 @@ import nodeFetch from 'node-fetch';
 
 export = (
     // istanbul ignore next
-    typeof window === 'undefined' ? (nodeFetch as typeof fetch) : fetch
+    typeof window === 'undefined' ? (nodeFetch as typeof fetch) : window.fetch.bind(window)
 );


### PR DESCRIPTION
I fixed up @rub1e's #232 solution for #230. I amended the commit so credit can go where it's due. There was an extra parentheses that created an error in the typescript compiler and the linter error was rendered on the wrong line in github.

I found the cause of the issue.

The typescript transpilation rewrites the import of the local fetch module to a commonjs require.
```js
var fetch_1 = __importDefault(require("./fetch"));
```

When transpiled `src/run_action.ts`

```js
    fetch(url, options)
```

translates to this line in `lib/run_action.js`

```js
    fetch_1.default(url, options)
```

and so the window fetch method is called on `fetch_1` as it's `this`.
