### PR TITLE
Make fetch function injectable

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -45,7 +45,6 @@ var forEach_1 = __importDefault(require("lodash/forEach"));
 var get_1 = __importDefault(require("lodash/get"));
 var assign_1 = __importDefault(require("lodash/assign"));
 var isPlainObject_1 = __importDefault(require("lodash/isPlainObject"));
-var fetch_1 = __importDefault(require("./fetch"));
 var abort_controller_1 = __importDefault(require("./abort-controller"));
 var object_to_query_param_string_1 = __importDefault(require("./object_to_query_param_string"));
 var airtable_error_1 = __importDefault(require("./airtable_error"));
@@ -83,7 +82,7 @@ var Base = /** @class */ (function () {
             controller.abort();
         }, this._airtable.requestTimeout);
         return new Promise(function (resolve, reject) {
-            fetch_1.default(url, requestOptions)
+            _this._airtable._fetch(url, requestOptions)
                 .then(function (resp) {
                 clearTimeout(timeout);
                 resp.statusCode = resp.status;
@@ -211,7 +210,7 @@ function _getErrorForNonObjectBody(statusCode, body) {
 }
 module.exports = Base;
 
-},{"./abort-controller":1,"./airtable_error":2,"./exponential_backoff_with_jitter":6,"./fetch":7,"./http_headers":9,"./object_to_query_param_string":11,"./package_version":12,"./run_action":16,"./table":17,"lodash/assign":163,"lodash/forEach":167,"lodash/get":168,"lodash/isPlainObject":183}],4:[function(require,module,exports){
+},{"./abort-controller":1,"./airtable_error":2,"./exponential_backoff_with_jitter":6,"./http_headers":9,"./object_to_query_param_string":11,"./package_version":12,"./run_action":16,"./table":17,"lodash/assign":163,"lodash/forEach":167,"lodash/get":168,"lodash/isPlainObject":183}],4:[function(require,module,exports){
 "use strict";
 /**
  * Given a function fn that takes a callback as its last argument, returns
@@ -709,7 +708,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 var exponential_backoff_with_jitter_1 = __importDefault(require("./exponential_backoff_with_jitter"));
 var object_to_query_param_string_1 = __importDefault(require("./object_to_query_param_string"));
 var package_version_1 = __importDefault(require("./package_version"));
-var fetch_1 = __importDefault(require("./fetch"));
 var abort_controller_1 = __importDefault(require("./abort-controller"));
 var userAgent = "Airtable.js/" + package_version_1.default;
 function runAction(base, method, path, queryParams, bodyData, callback, numAttempts) {
@@ -747,7 +745,8 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
     var timeout = setTimeout(function () {
         controller.abort();
     }, base._airtable.requestTimeout);
-    fetch_1.default(url, options)
+    base._airtable
+        ._fetch(url, options)
         .then(function (resp) {
         clearTimeout(timeout);
         if (resp.status === 429 && !base._airtable._noRetryIfRateLimited) {
@@ -782,7 +781,7 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
 }
 module.exports = runAction;
 
-},{"./abort-controller":1,"./exponential_backoff_with_jitter":6,"./fetch":7,"./object_to_query_param_string":11,"./package_version":12}],17:[function(require,module,exports){
+},{"./abort-controller":1,"./exponential_backoff_with_jitter":6,"./object_to_query_param_string":11,"./package_version":12}],17:[function(require,module,exports){
 "use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -6757,6 +6756,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 var base_1 = __importDefault(require("./base"));
 var record_1 = __importDefault(require("./record"));
 var table_1 = __importDefault(require("./table"));
+var fetch_1 = __importDefault(require("./fetch"));
 var airtable_error_1 = __importDefault(require("./airtable_error"));
 var Airtable = /** @class */ (function () {
     function Airtable(opts) {
@@ -6784,6 +6784,9 @@ var Airtable = /** @class */ (function () {
                     Airtable.noRetryIfRateLimited ||
                     defaultConfig.noRetryIfRateLimited,
             },
+            _fetch: {
+                value: opts.fetch || fetch_1.default
+            }
         });
         this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;
         if (!this._apiKey) {
@@ -6820,4 +6823,4 @@ var Airtable = /** @class */ (function () {
 }());
 module.exports = Airtable;
 
-},{"./airtable_error":2,"./base":3,"./record":15,"./table":17}]},{},["airtable"]);
+},{"./airtable_error":2,"./base":3,"./fetch":7,"./record":15,"./table":17}]},{},["airtable"]);

--- a/src/airtable.ts
+++ b/src/airtable.ts
@@ -1,6 +1,7 @@
 import Base from './base';
 import Record from './record';
 import Table from './table';
+import fetch from './fetch';
 import AirtableError from './airtable_error';
 import {AirtableBase} from './airtable_base';
 import type {ObjectMap} from './object_map';
@@ -14,6 +15,7 @@ class Airtable {
     readonly _customHeaders: CustomHeaders;
     readonly _endpointUrl: string;
     readonly _noRetryIfRateLimited: boolean;
+    readonly _fetch: typeof fetch;
 
     requestTimeout: number;
 
@@ -35,6 +37,7 @@ class Airtable {
             endpointUrl?: string;
             noRetryIfRateLimited?: boolean;
             requestTimeout?: number;
+            fetch?: typeof fetch;
         } = {}
     ) {
         const defaultConfig = Airtable.default_config();
@@ -63,6 +66,9 @@ class Airtable {
                     Airtable.noRetryIfRateLimited ||
                     defaultConfig.noRetryIfRateLimited,
             },
+            _fetch: {
+                value: opts.fetch || fetch
+            }
         });
 
         this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;

--- a/src/base.ts
+++ b/src/base.ts
@@ -2,7 +2,6 @@ import forEach from 'lodash/forEach';
 import get from 'lodash/get';
 import assign from 'lodash/assign';
 import isPlainObject from 'lodash/isPlainObject';
-import fetch from './fetch';
 import AbortController from './abort-controller';
 import objectToQueryParamString from './object_to_query_param_string';
 import AirtableError from './airtable_error';
@@ -63,7 +62,7 @@ class Base {
         }, this._airtable.requestTimeout);
 
         return new Promise((resolve, reject) => {
-            fetch(url, requestOptions)
+            this._airtable._fetch(url, requestOptions)
                 .then((resp: BaseResponse) => {
                     clearTimeout(timeout);
                     resp.statusCode = resp.status;

--- a/src/run_action.ts
+++ b/src/run_action.ts
@@ -1,7 +1,6 @@
 import exponentialBackoffWithJitter from './exponential_backoff_with_jitter';
 import objectToQueryParamString from './object_to_query_param_string';
 import packageVersion from './package_version';
-import fetch from './fetch';
 import AbortController from './abort-controller';
 
 const userAgent = `Airtable.js/${packageVersion}`;
@@ -46,7 +45,8 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
         controller.abort();
     }, base._airtable.requestTimeout);
 
-    fetch(url, options)
+    base._airtable
+        ._fetch(url, options)
         .then((resp: Response & {statusCode: Response['status']}) => {
             clearTimeout(timeout);
             if (resp.status === 429 && !base._airtable._noRetryIfRateLimited) {


### PR DESCRIPTION
This PR makes the `fetch` function used by `base.ts` _injectable_.

---

When setting the `fetch` property to be a function compatible with `window.fetch` signature like this

```javascript
new Airtable({ apiKey: key, fetch: (a, b) => console.log("New Fetch") });
```

that new function is used by `base.ts` and `run_action.ts` instead of `window.fetch`.

---

This is helpful for testing purposes and, for example, injecting API keys or logging requests.