### PR TITLE
Allow requestTimeout config

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -82,7 +82,7 @@ var Base = /** @class */ (function () {
         }
         var timeout = setTimeout(function () {
             controller.abort();
-        }, this._airtable.requestTimeout);
+        }, this._airtable._requestTimeout);
         return new Promise(function (resolve, reject) {
             fetch_1.default(url, requestOptions)
                 .then(function (resp) {
@@ -753,7 +753,7 @@ function runAction(base, method, path, queryParams, bodyData, callback, numAttem
     }
     var timeout = setTimeout(function () {
         controller.abort();
-    }, base._airtable.requestTimeout);
+    }, base._airtable._requestTimeout);
     fetch_1.default(url, options)
         .then(function (resp) {
         clearTimeout(timeout);
@@ -6792,8 +6792,10 @@ var Airtable = /** @class */ (function () {
                     Airtable.noRetryIfRateLimited ||
                     defaultConfig.noRetryIfRateLimited,
             },
+            _requestTimeout: {
+                value: opts.requestTimeout || Airtable.requestTimeout || defaultConfig.requestTimeout,
+            },
         });
-        this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;
         if (!this._apiKey) {
             throw new Error('An API key is required to connect to Airtable');
         }
@@ -6811,11 +6813,12 @@ var Airtable = /** @class */ (function () {
         };
     };
     Airtable.configure = function (_a) {
-        var apiKey = _a.apiKey, endpointUrl = _a.endpointUrl, apiVersion = _a.apiVersion, noRetryIfRateLimited = _a.noRetryIfRateLimited;
+        var apiKey = _a.apiKey, endpointUrl = _a.endpointUrl, apiVersion = _a.apiVersion, noRetryIfRateLimited = _a.noRetryIfRateLimited, requestTimeout = _a.requestTimeout;
         Airtable.apiKey = apiKey;
         Airtable.endpointUrl = endpointUrl;
         Airtable.apiVersion = apiVersion;
         Airtable.noRetryIfRateLimited = noRetryIfRateLimited;
+        Airtable.requestTimeout = requestTimeout;
     };
     Airtable.base = function (baseId) {
         return new Airtable().base(baseId);

--- a/src/airtable.ts
+++ b/src/airtable.ts
@@ -22,8 +22,7 @@ class Airtable {
     readonly _customHeaders: CustomHeaders;
     readonly _endpointUrl: string;
     readonly _noRetryIfRateLimited: boolean;
-
-    requestTimeout: number;
+    readonly _requestTimeout: number;
 
     static Base = Base;
     static Record = AirtableRecord;
@@ -34,6 +33,7 @@ class Airtable {
     static apiVersion: string;
     static endpointUrl: string;
     static noRetryIfRateLimited: boolean;
+    static requestTimeout: number;
 
     constructor(opts: Airtable.AirtableOptions = {}) {
         const defaultConfig = Airtable.default_config();
@@ -62,9 +62,11 @@ class Airtable {
                     Airtable.noRetryIfRateLimited ||
                     defaultConfig.noRetryIfRateLimited,
             },
+            _requestTimeout: {
+                value:
+                    opts.requestTimeout || Airtable.requestTimeout || defaultConfig.requestTimeout,
+            },
         });
-
-        this.requestTimeout = opts.requestTimeout || defaultConfig.requestTimeout;
 
         if (!this._apiKey) {
             throw new Error('An API key is required to connect to Airtable');
@@ -90,11 +92,16 @@ class Airtable {
         endpointUrl,
         apiVersion,
         noRetryIfRateLimited,
-    }: Pick<Airtable.AirtableOptions, 'apiKey' | 'endpointUrl' | 'apiVersion' | 'noRetryIfRateLimited'>): void {
+        requestTimeout,
+    }: Pick<
+        Airtable.AirtableOptions,
+        'apiKey' | 'endpointUrl' | 'apiVersion' | 'noRetryIfRateLimited' | 'requestTimeout'
+    >): void {
         Airtable.apiKey = apiKey;
         Airtable.endpointUrl = endpointUrl;
         Airtable.apiVersion = apiVersion;
         Airtable.noRetryIfRateLimited = noRetryIfRateLimited;
+        Airtable.requestTimeout = requestTimeout;
     }
 
     static base(baseId: string): Airtable.Base {

--- a/src/base.ts
+++ b/src/base.ts
@@ -77,7 +77,7 @@ class Base {
 
         const timeout = setTimeout(() => {
             controller.abort();
-        }, this._airtable.requestTimeout);
+        }, this._airtable._requestTimeout);
 
         return new Promise((resolve, reject) => {
             fetch(url, requestOptions)

--- a/src/run_action.ts
+++ b/src/run_action.ts
@@ -62,7 +62,7 @@ function runAction(
 
     const timeout = setTimeout(() => {
         controller.abort();
-    }, base._airtable.requestTimeout);
+    }, base._airtable._requestTimeout);
 
     fetch(url, options)
         .then(resp => {


### PR DESCRIPTION
- Closes #247 

This PR allows `requestTimeout` to be configured in the same way as the other `AirtableOptions`.