### PR TITLE
Fix: propagate errors happening in eachPage callback

### DIFF
--- a/src/run_action.ts
+++ b/src/run_action.ts
@@ -86,8 +86,8 @@ function runAction(
                         r.statusCode = resp.status;
                         callback(error, r, body);
                     })
-                    .catch(function() {
-                        callback(base._checkStatusForError(resp.status));
+                    .catch(function(e) {
+                        callback(base._checkStatusForError(resp.status) || e);
                     });
             }
         })


### PR DESCRIPTION
It happens that an error is thrown within the callback function passed to `table.select(...).eachPage(XXX)`. The previous code only recognizes network errors, With this change, errors thrown by the JS code will propagate, instead of having an obscure error:

```
Unhandled rejection
TypeError: Cannot read property 'offset' of undefined
[1]     at /home/ubuntu/em-projects/em-monorepo/airtable-babel-synchronisation/node_modules/airtable/lib/query.js:119:28
...
```

I don't know how to update the unit tests to maintain the 100% coverage. I'd be grateful if you could take it or advise on where/how this change should be tested.