### PR TITLE
Create UMD build and use that when airtable.js is included as a dependency in browser-targeted builds

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -7,6 +7,14 @@ module.exports = function(grunt) {
         pkg: pkg,
         browserify: {
             umd: {
+                // During our build script, we copy lib/airtable.js to lib/tmp_airtable.js and use the tmp file here.
+                // This is necessary because in our package.json we replace lib/airtable.js with lib/airtable.umd.js
+                // for browser builds. We have this setting because we want to make sure that when _other_ apps
+                // include airtable.js as a dependency and are bundled for a browser target, they bundle the UMD build
+                // rather than the node build. However, since we replace lib/airtable.js with lib/airtable.umd.js in
+                // browser builds, browserify is unable to use lib/airtable.js as the src in our own browser builds.
+                // Therefore, we copy it to a tmp file and use that as the src.
+                // GitHub issue https://github.com/browserify/browserify/issues/1746
                 src: './lib/tmp_airtable.js',
                 dest: './lib/airtable.umd.js',
                 options: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -6,8 +6,29 @@ module.exports = function(grunt) {
     grunt.initConfig({
         pkg: pkg,
         browserify: {
-            client: {
-                src: './lib/airtable.js',
+            umd: {
+                src: './lib/tmp_airtable.js',
+                dest: './lib/airtable.umd.js',
+                options: {
+                    transform: [
+                        [
+                            'envify',
+                            {
+                                _: 'purge',
+                                npm_package_version: pkg.version,
+                            },
+                        ],
+                    ],
+                    preBundleCB: function(b) {
+                        b.require('./lib/tmp_airtable.js', {expose: 'airtable'});
+                    },
+                    browserifyOptions: {
+                        standalone: 'Airtable',
+                    },
+                },
+            },
+            browser: {
+                src: './lib/tmp_airtable.js',
                 dest: './build/airtable.browser.js',
                 options: {
                     transform: [
@@ -20,7 +41,7 @@ module.exports = function(grunt) {
                         ],
                     ],
                     preBundleCB: function(b) {
-                        b.require('./lib/airtable.js', {expose: 'airtable'});
+                        b.require('./lib/tmp_airtable.js', {expose: 'airtable'});
                     },
                 },
             },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write '**/*.js'",
     "test": "jest --env node --coverage --no-cache",
     "test-unit": "jest --env node",
-    "prepare": "rm -rf lib/* && tsc && grunt browserify"
+    "prepare": "rm -rf lib/* && rm -f build/airtable.browser.js && tsc && cp lib/airtable.js lib/tmp_airtable.js && grunt browserify && rm lib/tmp_airtable.js"
   },
   "dependencies": {
     "@types/node": ">=8.0.0 <15",
@@ -25,6 +25,7 @@
   "browser": {
     "node-fetch": false,
     "abort-controller": false,
+    "./lib/airtable.js": "./lib/airtable.umd.js",
     "./lib/package_version": "./lib/package_version_browser"
   },
   "files": [

--- a/test/browser_build.test.js
+++ b/test/browser_build.test.js
@@ -3,25 +3,30 @@
 var fs = require('fs');
 var path = require('path');
 
-var BUILD_PATH = path.join(__dirname, '..', 'build', 'airtable.browser.js');
+var BUILD_PATHS = [
+    path.join(__dirname, '..', 'build', 'airtable.browser.js'),
+    path.join(__dirname, '..', 'lib', 'airtable.umd.js'),
+];
 
-describe('browser build', function() {
-    it("doesn't contain any environment variables", function(done) {
-        fs.readFile(BUILD_PATH, 'utf8', function(err, builtJs) {
-            if (err) {
-                done(err);
-                return;
-            }
+describe('browser builds', function() {
+    for (const buildPath of BUILD_PATHS) {
+        it("doesn't contain any environment variables", function(done) {
+            fs.readFile(buildPath, 'utf8', function(err, builtJs) {
+                if (err) {
+                    done(err);
+                    return;
+                }
 
-            var exceptions = [/process\.env\.NODE_DEBUG/, /process\.env = {}/];
+                var exceptions = [/process\.env\.NODE_DEBUG/, /process\.env = {}/];
 
-            var builtWithoutExceptions = exceptions.reduce(function(result, exception) {
-                return result.replace(exception, '');
-            }, builtJs);
+                var builtWithoutExceptions = exceptions.reduce(function(result, exception) {
+                    return result.replace(exception, '');
+                }, builtJs);
 
-            expect(builtWithoutExceptions).not.toContain('process.env');
+                expect(builtWithoutExceptions).not.toContain('process.env');
 
-            done();
+                done();
+            });
         });
-    });
+    }
 });


### PR DESCRIPTION
# Summary
## TLDR:
**Problem**: A reference to `process` was included in a block bundle when using cli-next, which causes a crash. This came from airtable.js.
**Solution**: Ensure that when airtable.js is used as a dependency in some other app, if the app is bundled for a browser environment, it bundles the browser build of airtable.js.

## Full explanation:
It seems some people are using airtable.js as a dependency in a client side app. (In this case, it happened to be a block but that's not actually a great example since blocks can use the blocks SDK. You could imagine someone using it in their own react app or something.) Typically airtable.js is intended to be used on the backend, but we do already have a browser build and describe how to use it in the browser in the README, so it's something we support. Right now, airtable.js is only really set up to be consumed either (1) in a node environment as a dependency that is `require`d or (2) in a browser environment by adding a script tag to the page that loads airtable.js. It is not set up to be consumed as a dependency that will be bundled into some larger bundle that targets a browser environment. If you try to do this, it will end up bundling the code that is intended to run in a node environment. As a result, the client-side bundle ends up containing references to process.env which results in an error when running the app in a browser
```
ReferenceError: process is not defined
    at Object../node_modules/airtable/lib/package_version_browser.js 
```

But why did it work when bundling a block with the old cli? The old cli used browserify. The original goal with browserify was to make it so that you could write client-side code in separate files and use `require()` to import things just like you do in node, but then have it all get bundled up so that the browser only loads 1 file. More succinctly, it "browser-ifies" node code. Taking it a step further, they chose to inject node globals into the bundle. `require` is actually created as a global in the browserify bundle, but they also inject globals for `process`, `__filename`, `__dirname`, `Buffer`, and `global` when those are detected in the code. So on the old cli, if a block includes airtable.js as a dependency, then when browserify bundles the block, it will detect the usage of `process.env` and inject a global polyfill for `process`. 

Since browserify came out, bundlers and the state of client side JS generally have moved in a different direction. The ES module format was introduced which provides a number of benefits over CommonJS modules, particularly when bundling for a browser environment since it is easier to tree shake. ES modules were first usable only with build tools, and not natively supported in either the browser or node. Build tools would translate ES module import/export syntax into either a bundle for a browser or CommonJS imports/exports for node. Modern browsers now support ES modules natively, and node will soon. But you can see that this is very different model from browserify's original design to basically take node code and make it run in a browser. Node is actually the _last_ environment to natively support ES modules! Browserify, to its credit, has adapted and can support other formats as well. But hopefully this gives context for why browserify chose to polyfill node globals by default – they wanted to "browserify" node code. Other bundlers which are not so node-first (including webpack 5) do not necessarily polyfill node globals by default, but provide a way to opt in to this.

One possible fix then is to update our webpack config in the new cli to polyfill node globals. However, I think the better solution is to fix airtable.js. We shouldn't be bundling code that is expected to run in a node environment into a build that is targeted for browsers in the first place. There are ways to avoid this so that you don't have to unnecessarily bloat a browser bundle with node polyfills.

Here, we have different options as well. We could write the code in an isomorphic way. This means adding conditionals (either in our code, or by using isomorphic libraries). With a proper build setup, these conditionals can even be stripped away at build time so that only the client-side case would be bundled for a browser-targeted bundle. Alternatively, you can write code in a non-isomorphic way, and rely on build tooling to transform it. This is what we've done. We have two separate builds: `tsc` builds for node, and browserify builds for the browser. (Not to be confused with browserify in the old cli! airtable.js also uses browserify for its own browser build and will continue to do so in this PR.) The code that references `process.env` in a non-isomorphic way is stripped away during the browser build.

So we already have a node build and a browser build. However, when airtable.js is used as a dependency and bundled into some other app, it is still using the node build. This is controlled by airtable.js's package.json. The `"main"` setting indicates the entry point to the dependency. If you want a different entry point for builds that target node vs. a browser, you can use the `"browser"` setting to provide a different entrypoint for builds targeting a browser.

<details>
<summary>Aside:</summary>
We already have a `"browser"` setting in the package.json. This setting is somewhat overloaded, and our existing usage of it is sort of for a different purpose. You can control more than just the entrypoint – you can actually replace or ignore other modules during the build. This is related to why you'll see that I copy lib/airtable.js to lib/tmp_airtable.js during the build process and I've added a comment in the gruntfile with more explanation.
</details>

<details>
<summary>Aside:</summary>
There's also a `"module"` setting in package.json, but it doesn't quite solve our issue. This is used when building for environments that support ES modules. Today, that would be builds targeting modern browsers. However, we currently say that airtable.js can be used in some older browsers which don't support ES modules, so we'd need to include these browsers in our target, which means the bundler would still use the `"main"` entrypoint.
</details>

However, we can't just point at the current browser build because this file cannot be consumed as a module. It's a script that, when executed, creates a global `require` variable and exposes 'airtable' as something that can be `require`d. We need something that is in a format we can use, such as a CommonJS module or ES module. So I've created an additional build that outputs in UMD format. A UMD build can be loaded via a script tag, imported by code that uses ES modules, or `require`d by code using CommonJS modules. This means you could even use this build when airtable.js is used as a dependency in a node app – it wouldn't error, but all the `process.env` references have been stripped away and we actually want those in a node environment! So we will only use this build when airtable.js is used as a dependency in a browser-targeted bundle.

As a bonus, this PR fixes the user agent header in client-side apps that use airtable.js as a dependency. Previously, it was set correctly by in the node environment and the existing browser build that is loaded via a script tag, but was `Airtable.js/undefined` for this use case. We now use the same mechanism as the existing browser build to set the header for this use case.

# Testing
`npm run test` succeeds

I also created a block, added airtable.js as a dependency, verified that I saw a crash on `process` not being defined. Then I replaced `node_modules/airtable/lib` with my local airtable.js lib folder and `node_modules/airtable/package.json` with my local airtable.js package.json and re-ran the block. Now it does not crash.