### PR TITLE
v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.11.3
+ * Adds a UMD build to use for browser-targeted builds. This fixes an issue where other apps that
+ use airtable.js as a dependency were bundling code that expects to run in a node environment when
+ building for a browser enviornment.
+
 # v0.11.2
  * Bump NPM package versions (#276, #281, #293, #296, #297, #298)
 

--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -443,7 +443,7 @@ module.exports = objectToQueryParamString;
 
 },{"lodash/isArray":79,"lodash/isNil":84,"lodash/keys":92}],12:[function(require,module,exports){
 "use strict";
-module.exports = "0.11.2";
+module.exports = "0.11.3";
 
 },{}],13:[function(require,module,exports){
 "use strict";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "license": "MIT",
   "homepage": "https://github.com/airtable/airtable.js",
   "repository": "git://github.com/airtable/airtable.js.git",

--- a/test/test_files/airtable.browser.js
+++ b/test/test_files/airtable.browser.js
@@ -443,7 +443,7 @@ module.exports = objectToQueryParamString;
 
 },{"lodash/isArray":79,"lodash/isNil":84,"lodash/keys":92}],12:[function(require,module,exports){
 "use strict";
-module.exports = "0.11.2";
+module.exports = "0.11.3";
 
 },{}],13:[function(require,module,exports){
 "use strict";


### PR DESCRIPTION
Adds a UMD build to use for browser-targeted builds. This fixes an issue where other apps that use airtable.js as a dependency were bundling code that expects to run in a node environment when building for a browser enviornment.