### PR TITLE
Fix prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "pretest": "npm run lint && npm run prepare && cp build/airtable.browser.js test/test_files; true",
     "lint": "eslint '*/**/*.{js,ts,tsx}'",
-    "format": "prettier --write '**/*.js'",
+    "format": "prettier --write '**/*.[j|t]s'",
     "test": "jest --env node --coverage --no-cache",
     "test-unit": "jest --env node",
     "prepare": "rm -rf lib/* && rm -f build/airtable.browser.js && tsc && cp lib/airtable.js lib/tmp_airtable.js && grunt browserify && rm lib/tmp_airtable.js"

--- a/src/base.ts
+++ b/src/base.ts
@@ -57,11 +57,7 @@ class Base {
 
         const controller = new AbortController();
         const headers = this._getRequestHeaders(
-            Object.assign(
-                {},
-                this._airtable._customHeaders,
-                options.headers ?? {}
-            )
+            Object.assign({}, this._airtable._customHeaders, options.headers ?? {})
         );
 
         const requestOptions: RequestInit = {

--- a/src/deprecate.ts
+++ b/src/deprecate.ts
@@ -11,7 +11,11 @@ const didWarnForDeprecation = {};
  *
  * @return a wrapped function
  */
-function deprecate<Args extends unknown[]>(fn: (...args: Args) => void, key: string, message: string): (...args: Args) => void {
+function deprecate<Args extends unknown[]>(
+    fn: (...args: Args) => void,
+    key: string,
+    message: string
+): (...args: Args) => void {
     return function(...args: Args): void {
         if (!didWarnForDeprecation[key]) {
             didWarnForDeprecation[key] = true;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,5 +1,4 @@
 // istanbul ignore file
 import nodeFetch from 'node-fetch';
 
-export =
-typeof window === 'undefined' ? (nodeFetch as typeof fetch) : window.fetch.bind(window);
+export = typeof window === 'undefined' ? (nodeFetch as typeof fetch) : window.fetch.bind(window);


### PR DESCRIPTION
# Summary
It appears the glob for prettier was never updated after this repo was converted to TypeScript.

# Testing
`npm run format` now formats ts and js files