### PR TITLE
Update select() and list() to use POST endpoint

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -475,9 +475,9 @@ var query_params_1 = require("./query_params");
  * with `Query.validateParams`.
  */
 var Query = /** @class */ (function () {
-    function Query(table, params) {
+    function Query(table, requestData) {
         this._table = table;
-        this._params = params;
+        this._requestData = requestData;
         this.firstPage = callback_to_promise_1.default(firstPage, this);
         this.eachPage = callback_to_promise_1.default(eachPage, this, 1);
         this.all = callback_to_promise_1.default(all, this);
@@ -554,17 +554,17 @@ function eachPage(pageCallback, done) {
     if (!isFunction_1.default(done) && done !== void 0) {
         throw new Error('The second parameter to `eachPage` must be a function or undefined');
     }
-    var path = "/" + this._table._urlEncodedNameOrId();
-    var params = __assign({}, this._params);
+    var path = "/" + this._table._urlEncodedNameOrId() + "/listRowsQuery";
+    var requestData = __assign({}, this._requestData);
     var inner = function () {
-        _this._table._base.runAction('get', path, params, null, function (err, response, result) {
+        _this._table._base.runAction('post', path, null, requestData, function (err, response, result) {
             if (err) {
                 done(err, null);
             }
             else {
                 var next = void 0;
                 if (result.offset) {
-                    params.offset = result.offset;
+                    requestData.offset = result.offset;
                     next = inner;
                 }
                 else {
@@ -984,9 +984,8 @@ var Table = /** @class */ (function () {
             done = opts;
             opts = {};
         }
-        var listRecordsParameters = __assign({ limit: limit,
-            offset: offset }, opts);
-        this._base.runAction('get', "/" + this._urlEncodedNameOrId() + "/", listRecordsParameters, null, function (err, response, results) {
+        var listRecordsParameters = __assign(__assign({ limit: limit }, (offset && { offset: offset })), opts);
+        this._base.runAction('post', "/" + this._urlEncodedNameOrId() + "/listRowsQuery", null, listRecordsParameters, function (err, response, results) {
             if (err) {
                 done(err);
                 return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "airtable",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=8.0.0 <15",

--- a/src/table.ts
+++ b/src/table.ts
@@ -152,7 +152,6 @@ class Table<TFields extends FieldSet> {
         if (params === void 0) {
             params = {};
         }
-
         if (arguments.length > 1) {
             console.warn(
                 `Airtable: \`select\` takes only one parameter, but it was given ${arguments.length} parameters. Use \`eachPage\` or \`firstPage\` to fetch records.`
@@ -369,15 +368,15 @@ class Table<TFields extends FieldSet> {
         }
         const listRecordsParameters = {
             limit,
-            offset,
+            ...(offset && {offset}),
             ...opts,
         };
 
         this._base.runAction(
-            'get',
-            `/${this._urlEncodedNameOrId()}/`,
-            listRecordsParameters,
+            'post',
+            `/${this._urlEncodedNameOrId()}/listRowsQuery`,
             null,
+            listRecordsParameters,
             (err, response, results) => {
                 if (err) {
                     done(err);

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -21,8 +21,9 @@ describe('list records', function() {
 
     it('lists records with a limit and offset without opts', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table/?limit=50&offset=offset000');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({limit: 50, offset: 'offset000'});
             res.json({
                 records: [
                     {
@@ -39,6 +40,7 @@ describe('list records', function() {
             .base('app123')
             .table('Table')
             .list(50, 'offset000', function(err, records, offset) {
+                console.log();
                 expect(err).toBeNull();
                 expect(records.length).toBe(1);
                 expect(records[0].getId()).toBe('recordA');
@@ -50,10 +52,13 @@ describe('list records', function() {
 
     it('lists records with a limit, offset, and opts', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe(
-                '/v0/app123/Table/?limit=50&offset=offset000&otherOptions=getpassedalong'
-            );
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({
+                limit: 50,
+                offset: 'offset000',
+                otherOptions: 'getpassedalong',
+            });
             res.json({
                 records: [
                     {
@@ -106,8 +111,9 @@ describe('list records', function() {
         var iterationCounter = 0;
 
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table/?limit=100&opts=arepassedalong');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({limit: 100, opts: 'arepassedalong'});
             res.json({
                 records: [
                     {
@@ -159,8 +165,9 @@ describe('list records', function() {
         };
 
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table/?limit=100');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({limit: 100});
             res.json(json);
         });
 
@@ -187,8 +194,9 @@ describe('list records', function() {
         };
 
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table/?limit=100');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({limit: 100});
             res.json(json);
         });
 
@@ -230,8 +238,9 @@ describe('list records', function() {
         var iterationCounter = 0;
 
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table/?limit=100');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({limit: 100});
             res.json({
                 records: [
                     {
@@ -254,8 +263,9 @@ describe('list records', function() {
                         expect(record.get('Name')).toBe('Rebecca');
 
                         testExpressApp.set('handler override', function(req, res) {
-                            expect(req.method).toBe('GET');
-                            expect(req.url).toBe('/v0/app123/Table/?limit=100&offset=offset123');
+                            expect(req.method).toBe('POST');
+                            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+                            expect(req.body).toEqual({limit: 100, offset: 'offset123'});
                             // Don't include an offset in second page of results
                             // to indicate that it is the final page of results
                             res.json({

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -21,8 +21,8 @@ describe('record selection', function() {
 
     it('selects records without params', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -51,8 +51,8 @@ describe('record selection', function() {
 
     it('selects records more than one record', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -89,8 +89,8 @@ describe('record selection', function() {
 
         testExpressApp.set('handler override', function(req, res) {
             if (iterationCounter === 0) {
-                expect(req.method).toBe('GET');
-                expect(req.url).toBe('/v0/app123/Table?');
+                expect(req.method).toBe('POST');
+                expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
                 res.json({
                     records: [
                         {
@@ -102,8 +102,9 @@ describe('record selection', function() {
                     offset: 'offsetABC',
                 });
             } else if (iterationCounter === 1) {
-                expect(req.method).toBe('GET');
-                expect(req.url).toBe('/v0/app123/Table?offset=offsetABC');
+                expect(req.method).toBe('POST');
+                expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+                expect(req.body).toEqual({offset: 'offsetABC'});
                 res.json({
                     records: [
                         {
@@ -173,6 +174,7 @@ describe('record selection', function() {
         testExpressApp.set('handler override', function(req, res) {
             expect(req.method).toBe('GET');
             expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -198,8 +200,8 @@ describe('record selection', function() {
         var iterationCounter = 0;
 
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -225,8 +227,9 @@ describe('record selection', function() {
                     });
 
                     testExpressApp.set('handler override', function(req, res) {
-                        expect(req.method).toBe('GET');
-                        expect(req.url).toBe('/v0/app123/Table?offset=offsetABC');
+                        expect(req.method).toBe('POST');
+                        expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+                        expect(req.body).toEqual({offset: 'offsetABC'});
                         res.json({
                             records: [
                                 {
@@ -257,8 +260,8 @@ describe('record selection', function() {
         var iterationCounter = 0;
 
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -285,8 +288,9 @@ describe('record selection', function() {
                         });
 
                         testExpressApp.set('handler override', function(req, res) {
-                            expect(req.method).toBe('GET');
-                            expect(req.url).toBe('/v0/app123/Table?offset=offsetABC');
+                            expect(req.method).toBe('POST');
+                            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+                            expect(req.body).toEqual({offset: 'offsetABC'});
                             res.json({
                                 records: [
                                     {
@@ -317,10 +321,14 @@ describe('record selection', function() {
 
     it('selects records with valid params', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe(
-                '/v0/app123/Table?maxRecords=50&sort%5B0%5D%5Bfield%5D=Name&sort%5B0%5D%5Bdirection%5D=desc&cellFormat=json&returnFieldsByFieldId=true'
-            );
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
+            expect(req.body).toEqual({
+                maxRecords: 50,
+                sort: [{field: 'Name', direction: 'desc'}],
+                cellFormat: 'json',
+                returnFieldsByFieldId: true,
+            });
             res.json({
                 records: [
                     {
@@ -353,8 +361,8 @@ describe('record selection', function() {
 
     it('selects records filters out invalid parameters and extra arguments without erroring', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -391,8 +399,8 @@ describe('record selection', function() {
 
     it('eachRecords errors on the first invalid parameter', function() {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -416,8 +424,8 @@ describe('record selection', function() {
 
     it('eachRecords errors on the second invalid parameter', function() {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -472,8 +480,8 @@ describe('record selection', function() {
 
     it('selects records the first page of records', function(done) {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
-            expect(req.url).toBe('/v0/app123/Table?');
+            expect(req.method).toBe('POST');
+            expect(req.url).toBe('/v0/app123/Table/listRowsQuery?');
             res.json({
                 records: [
                     {
@@ -503,7 +511,7 @@ describe('record selection', function() {
 
     it('firstPage errors without a done function', function() {
         testExpressApp.set('handler override', function(req, res) {
-            expect(req.method).toBe('GET');
+            expect(req.method).toBe('POST');
             expect(req.url).toBe('/v0/app123/Table?');
             res.json({
                 records: [

--- a/test/test_files/airtable.browser.js
+++ b/test/test_files/airtable.browser.js
@@ -475,9 +475,9 @@ var query_params_1 = require("./query_params");
  * with `Query.validateParams`.
  */
 var Query = /** @class */ (function () {
-    function Query(table, params) {
+    function Query(table, requestData) {
         this._table = table;
-        this._params = params;
+        this._requestData = requestData;
         this.firstPage = callback_to_promise_1.default(firstPage, this);
         this.eachPage = callback_to_promise_1.default(eachPage, this, 1);
         this.all = callback_to_promise_1.default(all, this);
@@ -554,17 +554,17 @@ function eachPage(pageCallback, done) {
     if (!isFunction_1.default(done) && done !== void 0) {
         throw new Error('The second parameter to `eachPage` must be a function or undefined');
     }
-    var path = "/" + this._table._urlEncodedNameOrId();
-    var params = __assign({}, this._params);
+    var path = "/" + this._table._urlEncodedNameOrId() + "/listRowsQuery";
+    var requestData = __assign({}, this._requestData);
     var inner = function () {
-        _this._table._base.runAction('get', path, params, null, function (err, response, result) {
+        _this._table._base.runAction('post', path, null, requestData, function (err, response, result) {
             if (err) {
                 done(err, null);
             }
             else {
                 var next = void 0;
                 if (result.offset) {
-                    params.offset = result.offset;
+                    requestData.offset = result.offset;
                     next = inner;
                 }
                 else {
@@ -984,9 +984,8 @@ var Table = /** @class */ (function () {
             done = opts;
             opts = {};
         }
-        var listRecordsParameters = __assign({ limit: limit,
-            offset: offset }, opts);
-        this._base.runAction('get', "/" + this._urlEncodedNameOrId() + "/", listRecordsParameters, null, function (err, response, results) {
+        var listRecordsParameters = __assign(__assign({ limit: limit }, (offset && { offset: offset })), opts);
+        this._base.runAction('post', "/" + this._urlEncodedNameOrId() + "/listRowsQuery", null, listRecordsParameters, function (err, response, results) {
             if (err) {
                 done(err);
                 return;


### PR DESCRIPTION
As part of the plan to migrate users that make large listRow request to the POST equivalent this makes use of the new POST endpoint by default when querying records though Airtable.js. During analysis, we found that ~37% of request that exceed 16k characters originate from requests made using the SDK so this will allow us to migrate a large chunk of users without them needing to take much action on their end.

The functionality of both `select()` and `list()` should remain the same, but the underlying logic that makes the request will now use the POST version of the endpoint rather than the existing GET endpoint.

More context in [the RFC](https://docs.google.com/document/d/1ISpC8lZfw6MINRcLtV4Opkt2RaqDIX0TF1T_xyYvrVQ/edit#) 