### PR TITLE
v0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.11.5
+ * Update select() and list() to support to use POST endpoint when GET url length would exceed Airtable's 16k character limit
+  * Update select() and list() to explicitly choose to use GET or POST endpoint via new 'method' arg
+
 # v0.11.4
  * Add support for returnFieldsByFieldId param.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airtable",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "airtable",
-      "version": "0.11.3",
+      "version": "0.11.5",
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=8.0.0 <15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "license": "MIT",
   "homepage": "https://github.com/airtable/airtable.js",
   "repository": "git://github.com/airtable/airtable.js.git",

--- a/src/query_params.ts
+++ b/src/query_params.ts
@@ -41,10 +41,20 @@ export const paramValidators = {
 
     userLocale: check(isString, 'the value for `userLocale` should be a string'),
 
+    method: check((method): method is 'json' | 'string' => {
+        return isString(method) && ['get', 'post'].includes(method);
+    }, 'the value for `method` should be "get" or "post"'),
+
     returnFieldsByFieldId: check(
         isBoolean,
         'the value for `returnFieldsByFieldId` should be a boolean'
     ),
+};
+
+export const URL_CHARACTER_LENGTH_LIMIT = 15000;
+
+export const shouldListRecordsParamBePassedAsParameter = (paramName: string): boolean => {
+    return paramName === 'timeZone' || paramName === 'userLocale';
 };
 
 export interface SortParameter<TFields> {
@@ -63,5 +73,6 @@ export interface QueryParams<TFields> {
     cellFormat?: 'json' | 'string';
     timeZone?: string;
     userLocale?: string;
+    method?: string;
     returnFieldsByFieldId?: boolean;
 }

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -280,4 +280,221 @@ describe('list records', function() {
                 }
             );
     });
+
+    it('should support passing timezone and userLocale as params', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('GET');
+            expect(req.url).toBe(
+                '/v0/app123/Table/?limit=50&offset=offset000&timeZone=America%2FLos_Angeles&userLocale=en-US'
+            );
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(50, 'offset000', {timeZone: 'America/Los_Angeles', userLocale: 'en-US'}, function(
+                err,
+                records,
+                offset
+            ) {
+                expect(err).toBeNull();
+                expect(records.length).toBe(1);
+                expect(records[0].getId()).toBe('recordA');
+                expect(records[0].get('Name')).toBe('Rebecca');
+                expect(offset).toBe('offsetABC');
+                done();
+            });
+    });
+
+    it('uses POST listRows endpoint when params exceed 15k characters', function(done) {
+        // Mock formula that is 15000 characters in length
+        const longFormula = [...Array(657)]
+            .map((_, i) => {
+                return `NOT({Name} = '${i}') & `;
+            })
+            .join();
+
+        expect(longFormula.length).toBe(15000);
+
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('POST');
+            // Request url should not include and query params and should
+            // use /listRecords endpoint with request body instead
+            expect(req.url).toBe(
+                '/v0/app123/Table/listRecords?timeZone=America%2FLos_Angeles&userLocale=en-US'
+            );
+            expect(req.body.filterByFormula).toBe(longFormula);
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(
+                50,
+                'offset000',
+                {
+                    filterByFormula: longFormula,
+                    timeZone: 'America/Los_Angeles',
+                    userLocale: 'en-US',
+                },
+                function(err, records, offset) {
+                    expect(err).toBeNull();
+                    expect(records.length).toBe(1);
+                    expect(records[0].getId()).toBe('recordA');
+                    expect(records[0].get('Name')).toBe('Rebecca');
+                    expect(offset).toBe('offsetABC');
+                    done();
+                }
+            );
+    });
+
+    it('uses POST listRows endpoint when "post" is specified for method', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('POST');
+            // Request url should not include and query params and should
+            // use /listRecords endpoint with request body instead
+            expect(req.url).toBe(
+                '/v0/app123/Table/listRecords?timeZone=America%2FLos_Angeles&userLocale=en-US'
+            );
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(
+                50,
+                'offset000',
+                {
+                    method: 'post',
+                    timeZone: 'America/Los_Angeles',
+                    userLocale: 'en-US',
+                },
+                function(err, records, offset) {
+                    expect(err).toBeNull();
+                    expect(records.length).toBe(1);
+                    expect(records[0].getId()).toBe('recordA');
+                    expect(records[0].get('Name')).toBe('Rebecca');
+                    expect(offset).toBe('offsetABC');
+                    done();
+                }
+            );
+    });
+
+    it('should support passing pageSize and offset with POST listRows endpoint', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('POST');
+            // Request url should not include and query params and should
+            // use /listRecords endpoint with request body instead
+            expect(req.url).toBe(
+                '/v0/app123/Table/listRecords?timeZone=America%2FLos_Angeles&userLocale=en-US'
+            );
+            expect(req.body.pageSize).toBe(1);
+            expect(req.body.offset).toBe('offset000');
+            res.json({
+                records: [
+                    {
+                        id: 'recordA',
+                        fields: {Name: 'Rebecca'},
+                        createdTime: '2020-04-20T16:20:00.000Z',
+                    },
+                ],
+                offset: 'offsetABC',
+            });
+        });
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(
+                1,
+                'offset000',
+                {
+                    method: 'post',
+                    timeZone: 'America/Los_Angeles',
+                    userLocale: 'en-US',
+                },
+                function(err, records, offset) {
+                    expect(err).toBeNull();
+                    expect(records.length).toBe(1);
+                    expect(records[0].getId()).toBe('recordA');
+                    expect(records[0].get('Name')).toBe('Rebecca');
+                    expect(offset).toBe('offsetABC');
+                    done();
+                }
+            );
+    });
+
+    it('can throw an error if POST listRow fails', function(done) {
+        testExpressApp.set('handler override', function(req, res) {
+            expect(req.method).toBe('POST');
+            // Request url should not include and query params and should
+            // use /listRecords endpoint with request body instead
+            expect(req.url).toBe(
+                '/v0/app123/Table/listRecords?timeZone=America%2FLos_Angeles&userLocale=en-US'
+            );
+
+            res.status(402).json({
+                error: {message: 'foo bar'},
+            });
+        });
+
+        // Mock formula that is 15000 characters in length
+        const longFormula = [...Array(657)]
+            .map((_, i) => {
+                return `NOT({Name} = '${i}') & `;
+            })
+            .join();
+
+        expect(longFormula.length).toBe(15000);
+
+        return airtable
+            .base('app123')
+            .table('Table')
+            .list(
+                50,
+                'offset000',
+                {
+                    filterByFormula: longFormula,
+                    timeZone: 'America/Los_Angeles',
+                    userLocale: 'en-US',
+                },
+                function(err, records, offset) {
+                    expect(err.statusCode).toBe(402);
+                    expect(err.message).toBe('foo bar');
+                    expect(records).toBeUndefined();
+                    expect(offset).toBeUndefined();
+                    done();
+                }
+            );
+    });
 });


### PR DESCRIPTION
- Update select() and list() to support to use POST endpoint when GET url length would exceed Airtable's 16k character limit
- Update select() and list() to explicitly choose to use GET or POST endpoint via new 'method' arg