### PR TITLE
Update README.md with personal access token, OAuth and new docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See the [technical requirements](https://support.airtable.com/hc/en-us/articles/
 
 There are three configurable options available:
 
-* `apiKey` - set the token to your secret API token. Visit [your account page](https://airtable.com/account) to create an API token.  (`AIRTABLE_API_KEY`)
+* `apiKey` - your secret API token. Visit [/create/tokens](https://airtable.com/create/tokens) to create a personal access token. [OAuth access tokens](https://airtable.com/developers/web/guides/oauth-integrations) can also be used.
 * `endpointUrl` - the API endpoint to hit. You might want to override
     it if you are using an API proxy (e.g. runscope.net) to debug your API calls. (`AIRTABLE_ENDPOINT_URL`)
 * `requestTimeout` - the timeout in milliseconds for requests. The default is 5 minutes (`300000`)
@@ -53,13 +53,13 @@ There are three configurable options available:
 You can set the options globally via `Airtable.configure`:
 
 ```js
-Airtable.configure({ apiKey: 'YOUR_SECRET_API_KEY' })
+Airtable.configure({ apiKey: 'YOUR_SECRET_API_TOKEN' })
 ```
 
 Globally via process env (e.g. in 12factor setup).
 
 ```sh
-export AIRTABLE_API_KEY=YOUR_SECRET_API_KEY
+export AIRTABLE_API_KEY=YOUR_SECRET_API_TOKEN
 ```
 
 You can also override the settings per connection:
@@ -71,6 +71,8 @@ const airtable = new Airtable({endpointUrl: 'https://api-airtable-com-8hw7i1oz63
 # Interactive documentation
 
 Go to https://airtable.com/api to see the interactive API documentation for your Airtable bases. Once you select a base, click the "JavaScript" tab to see code snippets using Airtable.js. It'll have examples for all operations you can perform against your base using this library.
+
+You can also view non-interactive API documentation at https://airtable.com/developers/web/api
 
 # Promises
 


### PR DESCRIPTION
* Update `apiKey` documentation to mention personal access tokens and OAuth access tokens instead of API key
* Add link to the non-interactive API documentation