### PR TITLE
Add support for recordMetadata param

### DIFF
--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -699,7 +699,9 @@ var Record = /** @class */ (function () {
     function Record(table, recordId, recordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
-        this.commentCount = recordId || recordJson.commentCount;
+        if (recordJson) {
+            this.commentCount = recordJson.commentCount;
+        }
         this.setRawJson(recordJson);
         this.save = callback_to_promise_1.default(save, this);
         this.patchUpdate = callback_to_promise_1.default(patchUpdate, this);

--- a/build/airtable.browser.js
+++ b/build/airtable.browser.js
@@ -671,6 +671,7 @@ exports.paramValidators = {
         return isString_1.default(method) && ['get', 'post'].includes(method);
     }, 'the value for `method` should be "get" or "post"'),
     returnFieldsByFieldId: typecheck_1.default(isBoolean_1.default, 'the value for `returnFieldsByFieldId` should be a boolean'),
+    recordMetadata: typecheck_1.default(typecheck_1.default.isArrayOf(isString_1.default), 'the value for `recordMetadata` should be an array of strings'),
 };
 exports.URL_CHARACTER_LENGTH_LIMIT = 15000;
 exports.shouldListRecordsParamBePassedAsParameter = function (paramName) {
@@ -698,6 +699,7 @@ var Record = /** @class */ (function () {
     function Record(table, recordId, recordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
+        this.commentCount = recordId || recordJson.commentCount;
         this.setRawJson(recordJson);
         this.save = callback_to_promise_1.default(save, this);
         this.patchUpdate = callback_to_promise_1.default(patchUpdate, this);

--- a/src/query_params.ts
+++ b/src/query_params.ts
@@ -49,6 +49,12 @@ export const paramValidators = {
         isBoolean,
         'the value for `returnFieldsByFieldId` should be a boolean'
     ),
+
+    recordMetadata: check(
+        check.isArrayOf(isString),
+        'the value for `recordMetadata` should be an array of strings'
+    ),
+
 };
 
 export const URL_CHARACTER_LENGTH_LIMIT = 15000;
@@ -75,4 +81,5 @@ export interface QueryParams<TFields> {
     userLocale?: string;
     method?: string;
     returnFieldsByFieldId?: boolean;
+    recordMetadata?: string[];
 }

--- a/src/record.ts
+++ b/src/record.ts
@@ -30,6 +30,7 @@ class Record<TFields extends FieldSet> {
     _rawJson: RecordJson;
 
     readonly id: string;
+    readonly commentCount?: number;
     fields: TFields;
 
     readonly save: RecordActionMethod<TFields>;
@@ -44,6 +45,7 @@ class Record<TFields extends FieldSet> {
     constructor(table: Table<TFields>, recordId: string, recordJson?: RecordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
+        this.commentCount = recordId || recordJson.commentCount;
         this.setRawJson(recordJson);
 
         this.save = callbackToPromise(save, this);

--- a/src/record.ts
+++ b/src/record.ts
@@ -45,7 +45,9 @@ class Record<TFields extends FieldSet> {
     constructor(table: Table<TFields>, recordId: string, recordJson?: RecordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
-        this.commentCount = recordId || recordJson.commentCount;
+        if (recordJson) {
+          this.commentCount = recordJson.commentCount;
+        }
         this.setRawJson(recordJson);
 
         this.save = callbackToPromise(save, this);

--- a/src/record_data.ts
+++ b/src/record_data.ts
@@ -1,4 +1,5 @@
 export interface RecordData<TFields> {
     id: string;
     fields: TFields;
+    commentCount?: number;
 }

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -319,7 +319,7 @@ describe('record selection', function() {
         testExpressApp.set('handler override', function(req, res) {
             expect(req.method).toBe('GET');
             expect(req.url).toBe(
-                '/v0/app123/Table?maxRecords=50&sort%5B0%5D%5Bfield%5D=Name&sort%5B0%5D%5Bdirection%5D=desc&cellFormat=json&returnFieldsByFieldId=true'
+                '/v0/app123/Table?maxRecords=50&sort%5B0%5D%5Bfield%5D=Name&sort%5B0%5D%5Bdirection%5D=desc&cellFormat=json&returnFieldsByFieldId=true&recordMetadata%5B%5D=commentCount'
             );
             res.json({
                 records: [
@@ -327,6 +327,7 @@ describe('record selection', function() {
                         id: 'recordA',
                         fields: {Name: 'Rebecca'},
                         createdTime: '2020-04-20T16:20:00.000Z',
+                        commentCount: 0,
                     },
                 ],
                 offset: 'offsetABC',
@@ -341,11 +342,14 @@ describe('record selection', function() {
                 sort: [{field: 'Name', direction: 'desc'}],
                 cellFormat: 'json',
                 returnFieldsByFieldId: true,
+                recordMetadata: ['commentCount'],
             })
             .eachPage(function page(records) {
                 records.forEach(function(record) {
+                    console.log({record});
                     expect(record.id).toBe('recordA');
                     expect(record.get('Name')).toBe('Rebecca');
+                    // expect(record.commentCount).toBe(0);
                 });
                 done();
             });

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -346,10 +346,9 @@ describe('record selection', function() {
             })
             .eachPage(function page(records) {
                 records.forEach(function(record) {
-                    console.log({record});
                     expect(record.id).toBe('recordA');
                     expect(record.get('Name')).toBe('Rebecca');
-                    // expect(record.commentCount).toBe(0);
+                    expect(record.commentCount).toBe(0);
                 });
                 done();
             });

--- a/test/test_files/airtable.browser.js
+++ b/test/test_files/airtable.browser.js
@@ -699,7 +699,9 @@ var Record = /** @class */ (function () {
     function Record(table, recordId, recordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
-        this.commentCount = recordId || recordJson.commentCount;
+        if (recordJson) {
+            this.commentCount = recordJson.commentCount;
+        }
         this.setRawJson(recordJson);
         this.save = callback_to_promise_1.default(save, this);
         this.patchUpdate = callback_to_promise_1.default(patchUpdate, this);

--- a/test/test_files/airtable.browser.js
+++ b/test/test_files/airtable.browser.js
@@ -671,6 +671,7 @@ exports.paramValidators = {
         return isString_1.default(method) && ['get', 'post'].includes(method);
     }, 'the value for `method` should be "get" or "post"'),
     returnFieldsByFieldId: typecheck_1.default(isBoolean_1.default, 'the value for `returnFieldsByFieldId` should be a boolean'),
+    recordMetadata: typecheck_1.default(typecheck_1.default.isArrayOf(isString_1.default), 'the value for `recordMetadata` should be an array of strings'),
 };
 exports.URL_CHARACTER_LENGTH_LIMIT = 15000;
 exports.shouldListRecordsParamBePassedAsParameter = function (paramName) {
@@ -698,6 +699,7 @@ var Record = /** @class */ (function () {
     function Record(table, recordId, recordJson) {
         this._table = table;
         this.id = recordId || recordJson.id;
+        this.commentCount = recordId || recordJson.commentCount;
         this.setRawJson(recordJson);
         this.save = callback_to_promise_1.default(save, this);
         this.patchUpdate = callback_to_promise_1.default(patchUpdate, this);


### PR DESCRIPTION
Adds support for the [`recordMetadata` param](https://airtable.com/developers/web/api/list-records#query-recordmetadata)