### PR TITLE
fix: TS error when setting date to null

### DIFF
--- a/src/field_set.ts
+++ b/src/field_set.ts
@@ -4,6 +4,7 @@ import {Attachment} from './attachment';
 export interface FieldSet {
     [key: string]:
         | undefined
+        | null
         | string
         | number
         | boolean


### PR DESCRIPTION
To set a date to blank you must send null as the value. when sending undefined the data is not reset.