### PR TITLE
Update SimpleHTTPServer to http.server in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For a demo, run:
 
 ```sh
 cd test/test_files
-python -m SimpleHTTPServer
+python -m http.server
 ```
 
 Edit `test/test_files/index.html` - put your `BASE_ID` and `API_KEY` (Be careful! You are putting your API key on a web page! Create a separate account and share only one base with it.)


### PR DESCRIPTION
This pull request updates the command used to start a simple HTTP server in the project's README.md. 
The previous command, `python -m SimpleHTTPServer`, is deprecated in Python 3.x and has been replaced by `python -m http.server`.

This change ensures that the instructions in the README are up-to-date and compatible with current Python versions.

Key changes:

- Replaced `python -m SimpleHTTPServer` with `python -m http.server`.
